### PR TITLE
Switched to using EF type config classes for modularity

### DIFF
--- a/MiniIndex/Data/Configuration/MiniTagEntityConfiguration.cs
+++ b/MiniIndex/Data/Configuration/MiniTagEntityConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MiniIndex.Models;
+
+namespace MiniIndex.Data.Configuration
+{
+    public class MiniTagEntityConfiguration : IEntityTypeConfiguration<MiniTag>
+    {
+        public void Configure(EntityTypeBuilder<MiniTag> builder)
+        {
+            builder.HasKey(t => new { t.MiniID, t.TagID });
+
+            builder.HasOne(pt => pt.Mini)
+                .WithMany(p => p.MiniTags)
+                .HasForeignKey(pt => pt.MiniID);
+
+            builder.HasOne(pt => pt.Tag)
+                .WithMany(t => t.MiniTags)
+                .HasForeignKey(pt => pt.TagID);
+        }
+    }
+}

--- a/MiniIndex/Data/MiniIndexContext.cs
+++ b/MiniIndex/Data/MiniIndexContext.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using MiniIndex.Models;
 
 namespace MiniIndex.Models
 {
     public class MiniIndexContext : IdentityDbContext
     {
-        public MiniIndexContext (DbContextOptions<MiniIndexContext> options)
+        public MiniIndexContext(DbContextOptions<MiniIndexContext> options)
             : base(options)
         {
         }
@@ -24,18 +19,7 @@ namespace MiniIndex.Models
         {
             base.OnModelCreating(modelBuilder);
 
-            modelBuilder.Entity<MiniTag>()
-                .HasKey(t => new { t.MiniID, t.TagID });
-
-            modelBuilder.Entity<MiniTag>()
-                .HasOne(pt => pt.Mini)
-                .WithMany(p => p.MiniTags)
-                .HasForeignKey(pt => pt.MiniID);
-
-            modelBuilder.Entity<MiniTag>()
-                .HasOne(pt => pt.Tag)
-                .WithMany(t => t.MiniTags)
-                .HasForeignKey(pt => pt.TagID);
+            modelBuilder.ApplyConfigurationsFromAssembly(GetType().Assembly);
         }
     }
 }


### PR DESCRIPTION
Addresses #91 by moving EF entity config to separate classes and using the builder method to automatically load them all in.

Also addresses #66 