### PR TITLE
Adding a page to facilitate improving tags

### DIFF
--- a/MiniIndex/Pages/Admin/Index.cshtml.cs
+++ b/MiniIndex/Pages/Admin/Index.cshtml.cs
@@ -26,6 +26,7 @@ namespace MiniIndex.Pages.Admin
                             .ThenInclude(mt => mt.Tag)
                         .Include(m => m.Creator)
                         .Where(m => m.Status == Status.Pending)
+                        .OrderByDescending(m => m.MiniTags.Count())
                         .AsNoTracking()
                         .ToListAsync();
         }

--- a/MiniIndex/Pages/Index.cshtml.cs
+++ b/MiniIndex/Pages/Index.cshtml.cs
@@ -26,12 +26,12 @@ namespace MiniIndex.Pages
 
             Mini = minis
                 .Include(m => m.Creator)
-                .Where(m=>m.Status==Status.Approved)
+                .Where(m => m.Status==Status.Approved)
                 .OrderByDescending(m => m.ID)
                 .Take(4)
                 .ToList();
 
-            MiniCount = minis.Count();
+            MiniCount = minis.Where(m => m.Status==Status.Approved).Count();
 
         }
     }

--- a/MiniIndex/Pages/Minis/Details.cshtml
+++ b/MiniIndex/Pages/Minis/Details.cshtml
@@ -70,43 +70,47 @@
 
         <div class="col-md-6">
             <h3>Tags</h3>
-            <div id="UsedTags">
-                @foreach (var MiniTag in Model.Mini.MiniTags)
-                {
-
-                    @if (SignInManager.IsSignedIn(User))
+            @if (!SignInManager.IsSignedIn(User))
+            {
+                    <p><strong>Register an account and login to add or remove tags.</strong></p>
+            }
+                <div id="UsedTags">
+                    @foreach (var MiniTag in Model.Mini.MiniTags)
                     {
-                        @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
+
+                        @if (SignInManager.IsSignedIn(User))
                         {
-                            <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <b>@MiniTag.Tag.TagName</b></a>
+                            @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
+                            {
+                                <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <b>@MiniTag.Tag.TagName</b></a>
+                            }
+                            else
+                            {
+                                <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <small>@MiniTag.Tag.Category:</small> <b>@MiniTag.Tag.TagName</b></a>
+                            }
+
                         }
                         else
                         {
-                            <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <small>@MiniTag.Tag.Category:</small> <b>@MiniTag.Tag.TagName</b></a>
-                        }
-
-                    }
-                    else
-                    {
-                        @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
-                        {
-                            <span class="badge badge-primary">
-                                @MiniTag.Tag.TagName
-                            </span>
-                        }
-                        else
-                        {
-                            <span class="badge badge-primary">
-                                <small>@MiniTag.Tag.Category:</small> @MiniTag.Tag.TagName
-                            </span>
+                            @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
+                            {
+                                <span class="badge badge-primary">
+                                    @MiniTag.Tag.TagName
+                                </span>
+                            }
+                            else
+                            {
+                                <span class="badge badge-primary">
+                                    <small>@MiniTag.Tag.Category:</small> @MiniTag.Tag.TagName
+                                </span>
+                            }
                         }
                     }
-                }
-            </div>
-            <div id="AddedTags">
+                </div>
+                <div id="AddedTags">
 
+                </div>
             </div>
-        </div>
     </div>
 
     @if (SignInManager.IsSignedIn(User))

--- a/MiniIndex/Pages/Minis/Help.cshtml
+++ b/MiniIndex/Pages/Minis/Help.cshtml
@@ -1,0 +1,39 @@
+﻿@page
+@inject SignInManager<IdentityUser> SignInManager
+@model MiniIndex.Pages.Minis.HelpModel
+
+@{
+    ViewData["Title"] = "Help us Tag Minis";
+}
+<h1>Minis to Tag</h1>
+<p>
+    The Mini Index is possible because of people like you submitting and tagging Minis. 
+    This is the list of Minis that have been submitted but haven't been approved yet, either because we haven't got around to it yet, or they need more tags.
+    If you want to help out, choose any minis below and try to improve the tags!
+</p>
+
+<div class="album py-5 bg-light">
+    <div class="container">
+        <div class="row">
+            @if (Model.Mini.Count() == 0)
+            {
+                <div align="center">
+                    <h1>All submitted Minis have been approved!</h1>
+                    <hr />
+                    <h2>To help you now, find a mini on Thingiverse or elsewhere, come back and <a href="/Minis/Create">add it here</a> so that the next person can find it easier!</h2>
+                </div>
+            }
+
+            @foreach (var item in Model.Mini)
+            {
+
+                <div class="col-md-4">
+                    <div class="card mb-4 shadow-sm">
+                        <a asp-page="./Details" asp-route-id="@item.ID">
+                            <img class="card-img-top" src="@item.Thumbnail" width="314" height="236" />
+                        </a>
+                    </div>
+                </div>
+            }
+        </div>
+</div>

--- a/MiniIndex/Pages/Minis/Help.cshtml.cs
+++ b/MiniIndex/Pages/Minis/Help.cshtml.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using MiniIndex.Models;
+
+namespace MiniIndex.Pages.Minis
+{
+    public class HelpModel : PageModel
+    {
+        public HelpModel (
+        UserManager<IdentityUser> userManager,
+        SignInManager<IdentityUser> signInManager,
+        MiniIndexContext context)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _context = context;
+        }
+
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly SignInManager<IdentityUser> _signInManager;
+        private readonly MiniIndexContext _context;
+
+        public IList<Mini> Mini { get; set; }
+
+        public async Task OnGetAsync()
+        {
+            IdentityUser user = await _userManager.GetUserAsync(User);
+
+            IQueryable<Mini> minis = from m in _context.Mini select m;
+
+            Mini = await _context.Mini
+                        .Include(m => m.MiniTags)
+                        .Where(m => m.Status == Status.Pending)
+                        .OrderBy(m => m.MiniTags.Count())
+                        .AsNoTracking()
+                        .ToListAsync();
+
+        }
+    }
+}

--- a/MiniIndex/Pages/Shared/_Layout.cshtml
+++ b/MiniIndex/Pages/Shared/_Layout.cshtml
@@ -45,6 +45,9 @@
                     <a class="nav-link" href="/Creators/Browse">Browse Creators</a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link" href="/Minis/Help">Help Tag Minis</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link" href="/Minis/Create">Submit a mini</a>
                 </li>
                 @if (User.IsInRole("Moderator"))

--- a/MiniIndex/Startup.cs
+++ b/MiniIndex/Startup.cs
@@ -43,11 +43,11 @@ namespace MiniIndex
                     options.UseSqlServer(Configuration.GetConnectionString("MiniIndexContext")));
 
             services.AddAuthentication()
-                .AddFacebook(facebookOptions =>
+                /*.AddFacebook(facebookOptions =>
                 {
                     facebookOptions.AppId = Configuration["Authentication:Facebook:AppId"];
                     facebookOptions.AppSecret = Configuration["Authentication:Facebook:AppSecret"];
-                });
+                })*/;
 
             services.AddTransient<IEmailSender, EmailSender>();
             services.Configure<AuthMessageSenderOptions>(Configuration);

--- a/MiniIndex/Startup.cs
+++ b/MiniIndex/Startup.cs
@@ -43,11 +43,11 @@ namespace MiniIndex
                     options.UseSqlServer(Configuration.GetConnectionString("MiniIndexContext")));
 
             services.AddAuthentication()
-                /*.AddFacebook(facebookOptions =>
+                .AddFacebook(facebookOptions =>
                 {
                     facebookOptions.AppId = Configuration["Authentication:Facebook:AppId"];
                     facebookOptions.AppSecret = Configuration["Authentication:Facebook:AppSecret"];
-                })*/;
+                });
 
             services.AddTransient<IEmailSender, EmailSender>();
             services.Configure<AuthMessageSenderOptions>(Configuration);


### PR DESCRIPTION
Starting to address #64, this page shows all pending Minis. I'll follow this up soon by submitting a bunch of Minis that I don't have time to go through and tag, hopefully driving a bit more lightweight engagement by offering people who want to contribute the ability to just hit a few tags instead of submitting whole models.

If we get around to #87 or #63 soon that'll make this even more useful.