### PR TITLE
Adding super basic tag suggestions based on mini name

### DIFF
--- a/MiniIndex/Pages/Minis/Details.cshtml
+++ b/MiniIndex/Pages/Minis/Details.cshtml
@@ -128,6 +128,19 @@
 
                 <div id="UnusedTags">
 
+                    @if (User.IsInRole("Moderator") && Model.SimilarTags.Count > 0)
+                    {
+                        <div class="add-tag-div">
+                            <h3 class="add-tag-header">Recommended Tags</h3>
+                            @foreach (var Tag in Model.SimilarTags)
+                            {
+                                <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                            }
+                        </div>
+                        <hr/>
+                    }
+
+
                     <div class="add-tag-div">
                         <h3 class="add-tag-header">Genre</h3>
                         @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Genre"))
@@ -149,10 +162,10 @@
 
 
                         @foreach (var Tag in Model.UnusedTags.Where(m => !string.IsNullOrEmpty(m.Category.ToString())
-                                                                     && m.Category.ToString() != "Genre"
-                                                                     && m.Category.ToString() != "OtherDescription"
-                                                                     && m.Category.ToString() != "CreatureName"
-                                                                      && m.Category.ToString() != "Use"))
+                                                                   && m.Category.ToString() != "Genre"
+                                                                   && m.Category.ToString() != "OtherDescription"
+                                                                   && m.Category.ToString() != "CreatureName"
+                                                                    && m.Category.ToString() != "Use"))
                         {
                             @if (Tag.Category.ToString() != PreviousCategory)
                             {

--- a/MiniIndex/Pages/Minis/Details.cshtml.cs
+++ b/MiniIndex/Pages/Minis/Details.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using MiniIndex.Models;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 
 namespace MiniIndex.Pages.Minis
@@ -14,6 +15,8 @@ namespace MiniIndex.Pages.Minis
         public Mini Mini { get; set; }
         public List<Tag> UnusedTags { get; set; }
         public List<Tag> MiscTags { get; set; }
+        public List<Tag> WordMatchingTags { get; set; }
+        public List<Tag> SimilarTags { get; set; }
 
         public DetailsModel(MiniIndexContext context)
         {
@@ -34,6 +37,9 @@ namespace MiniIndex.Pages.Minis
                 .Include(m => m.User)
                 .FirstOrDefaultAsync(m => m.ID == id);
 
+
+
+
             UnusedTags = _context
                 .Tag
                 .AsEnumerable()
@@ -41,6 +47,35 @@ namespace MiniIndex.Pages.Minis
                 .OrderBy(m => m.Category.ToString())
                 .ThenBy(m => m.TagName)
                 .ToList();
+
+
+            if (User.IsInRole("Moderator"))
+            {
+                string[] NameSplit = Mini.Name.ToLower().Split(' ');
+
+                WordMatchingTags = _context.Tag
+                    .Where(t => NameSplit.Contains(t.TagName.ToLower()))
+                    .ToList();
+
+                //TODO - I'm sure someone who knows LINQ could clean this up a lot.
+                if (WordMatchingTags.Count > 0)
+                {
+                    List<Mini> SimilarMinis = _context.Mini
+                                .Include(m => m.MiniTags)
+                                    .ThenInclude(mt => mt.Tag)
+                                    .AsEnumerable()
+                                .Where(m => m.MiniTags.Select(mt => mt.Tag).Intersect(WordMatchingTags).Any())
+                                .ToList();
+
+                    List<MiniTag> SimilarMiniTags = SimilarMinis.SelectMany(m => m.MiniTags).ToList();
+                    SimilarTags = SimilarMiniTags.GroupBy(mt => mt.Tag).Select(grp => grp.First().Tag).Except(Mini.MiniTags.Select(mt => mt.Tag)).ToList();
+                }
+                else
+                {
+                    SimilarTags = new List<Tag>();
+                }
+            }
+
 
             if (Mini == null)
             {


### PR DESCRIPTION
Super basic implementation for #87. As part of #100 I'm at ~600 minis indexed but untagged, so I want to add something to make tagging slightly quicker for myself. This isn't really a great approach (words like "and" in a name will probably need to be hardcoded to be ignored) but it'll make my life a bit easier.