### PR TITLE
Fix stretched images

### DIFF
--- a/MiniIndex/wwwroot/css/site.css
+++ b/MiniIndex/wwwroot/css/site.css
@@ -43,3 +43,7 @@ body {
 .Rejected {
     background-color: #dc3545;
 }
+
+.card-img-top {
+    object-fit:contain;
+}


### PR DESCRIPTION
Putting object-fit: contain on card images stops portrait images from being stretched out to landscape and instead centres them inside the container img element.