### PR TITLE
Removing duplicate items from context

### DIFF
--- a/MiniIndex.Core/Submissions/MiniSubmissionHandler.cs
+++ b/MiniIndex.Core/Submissions/MiniSubmissionHandler.cs
@@ -64,7 +64,10 @@ namespace MiniIndex.Core.Submissions
 
             if (foundCreator != null)
             {
+                _context.Remove(mini.Creator);
                 mini.Creator = foundCreator;
+
+                _context.Remove(currentSource.Site);
                 currentSource.Site = matchingSource;
 
                 return;


### PR DESCRIPTION
Entity Framework has a long-standing issue with orphaned items. If a parent item has a reference to a child, and you change that reference to a different child, the navigation property is updated but the old child remains in the change tracker and will still be added to the database. (Similarly, if you retrieve something with a collection of child items, remove something from the collection, and save the parent, it doesn't actually remove the child item from the database).

Manually removing the added items will solve the problem, but ultimately I'd like to look at hooking into the change tracker to detect and handle this.

(Actually, *ultimately* I'd like EF to handle this properly by itself, but that's beyond my control.)

Resolves #134 