### PR TITLE
Filtering out verbose and information events from AppInsights.

### DIFF
--- a/MiniIndex/AppInsightsFilter.cs
+++ b/MiniIndex/AppInsightsFilter.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+
+namespace MiniIndex
+{
+    public class AppInsightsFilter : ITelemetryProcessor
+    {
+        private ITelemetryProcessor Next { get; set; }
+
+        public AppInsightsFilter(ITelemetryProcessor next)
+        {
+            Next = next;
+        }
+
+        public void Process(ITelemetry item)
+        {
+            if (!OKtoSend(item)) { return; }
+
+            Next.Process(item);
+        }
+
+        private bool OKtoSend(ITelemetry item)
+        {
+            var traceTelemetry = item as TraceTelemetry;
+            if (traceTelemetry == null)
+            {
+                return true;
+            }
+
+            if (traceTelemetry.SeverityLevel == SeverityLevel.Verbose || traceTelemetry.SeverityLevel == SeverityLevel.Information)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}
+

--- a/MiniIndex/Startup.cs
+++ b/MiniIndex/Startup.cs
@@ -70,6 +70,8 @@ namespace MiniIndex
             services.AddTransient<IEmailSender, EmailSender>();
             services.Configure<AuthMessageSenderOptions>(Configuration);
             services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsTelemetryProcessor<AppInsightsFilter>();
+
 
             services.IncludeRegistry<CoreServices>();
         }


### PR DESCRIPTION
The changes around logging don't stop AppInsights, and Azure is projecting AppInsights will cost more than everything else this month... So filtering most of the crud out.