### PR TITLE
Support for searching Minis that haven't been approved yet.

### DIFF
--- a/MiniIndex.Core/Minis/Search/MiniSearchRequest.cs
+++ b/MiniIndex.Core/Minis/Search/MiniSearchRequest.cs
@@ -22,6 +22,7 @@ namespace MiniIndex.Core.Minis.Search
             set => _tags = value ?? Enumerable.Empty<string>();
         }
         public bool FreeOnly { get; set; }
+        public bool IncludeUnapproved { get; set; }
 
         public PageInfo PageInfo { get; set; }
     }

--- a/MiniIndex.Core/Minis/Search/MiniSearchRequestHandler.cs
+++ b/MiniIndex.Core/Minis/Search/MiniSearchRequestHandler.cs
@@ -27,9 +27,18 @@ namespace MiniIndex.Minis.Handlers
                 .Include(m => m.Creator)
                 .Include(m => m.Sources)
                     .ThenInclude(s => s.Site)
-                .Where(m => m.Status == Status.Approved)
                 .OrderByDescending(m => m.ApprovedTime)
                     .ThenByDescending(m => m.ID);
+
+            //TODO - Can this be optimized?
+            if (request.IncludeUnapproved)
+            {
+                search = search.Where(m => (m.Status == Status.Approved || m.Status == Status.Pending));
+            }
+            else
+            {
+                search = search.Where(m => m.Status == Status.Approved);
+            }
 
             if (request.FreeOnly)
             {

--- a/MiniIndex.Core/Submissions/MiniSubmissionHandler.cs
+++ b/MiniIndex.Core/Submissions/MiniSubmissionHandler.cs
@@ -41,6 +41,7 @@ namespace MiniIndex.Core.Submissions
 
             mini = await parser.ParseFromUrl(request.Url);
             mini.User = request.User;
+            mini.Status = Status.Unindexed;
 
             _context.Add(mini);
 

--- a/MiniIndex/Minis/BrowseMinis.cshtml
+++ b/MiniIndex/Minis/BrowseMinis.cshtml
@@ -65,6 +65,7 @@
                                     pageSize = Model.Minis.PageSize,
                                     pageIndex,
                                     FreeOnly = Model.SearchModel.FreeOnly,
+                                    IncludeUnapproved = Model.SearchModel.IncludeUnapproved,
                                     Tags = string.Join(",", Model.SearchModel.Tags)
                                 },
                                 new { @class = "btn" })

--- a/MiniIndex/Minis/MiniSearchModel.cs
+++ b/MiniIndex/Minis/MiniSearchModel.cs
@@ -10,6 +10,7 @@ namespace MiniIndex.Minis
         public string Tags { get; set; }
 
         public bool FreeOnly { get; set; }
+        public bool IncludeUnapproved { get; set; }
 
         public SearchSupportingInfo SupportingInfo { get; set; }
         public SelectList TagOptions { get; internal set; }

--- a/MiniIndex/Minis/MiniSearchView.cshtml
+++ b/MiniIndex/Minis/MiniSearchView.cshtml
@@ -3,38 +3,50 @@
     <div class="container-fluid">
         @using (Html.BeginForm(FormMethod.Get))
         {
-            <ul class="nav flex-column">
-                <li class="nav-item form-group">
-                    @Html.LabelFor(x => x.SearchString, "Search by name")
-                    <a href="#" class="badge badge-pill badge-primary" data-toggle="tooltip" data-placement="right" title="Searches the name of the mini and orders by most relevant">
-                            <span class="oi oi-info"></span>
-                    </a> 
-                    @Html.TextBoxFor(x => x.SearchString, new { @class = "form-control", placeholder = "Search for..." })
-                </li>
-                <li class="nav-item form-group">
-                    @Html.LabelFor(x => x.Tags, "Filter by tags")
-                    <a href="#" class="badge badge-pill badge-primary" data-toggle="tooltip" data-placement="right" title="Show only Minis with the selected tags. If no name search is specified, orders by most recently added">
-                            <span class="oi oi-info"></span>
-                    </a>
-                    <input id="tagsInput" class="form-control" type="text" placeholder="Find tags..." />
-                    @Html.HiddenFor(x => x.Tags, new { id = "tagsValue" })
-                </li>
-                <li class="nav-item form-group form-check">
-                    @Html.CheckBoxFor(x => x.FreeOnly,
-                        new
-                        {
-                            @class = "form-check-input"
-                        })
-                    @Html.LabelFor(x => x.FreeOnly, "Free Minis Only",
-                        new
-                        {
-                            @class = "form-check-label"
-                        })
-                </li>
-                <li class="nav-item form-group">
-                    <input type="submit" value="Search" class="btn btn-primary btn-block" />
-                </li>
-            </ul>
+        <ul class="nav flex-column">
+            <li class="nav-item form-group">
+                @Html.LabelFor(x => x.SearchString, "Search by name")
+                <a href="#" class="badge badge-pill badge-primary" data-toggle="tooltip" data-placement="right" title="Searches the name of the mini and orders by most relevant">
+                    <span class="oi oi-info"></span>
+                </a>
+                @Html.TextBoxFor(x => x.SearchString, new { @class = "form-control", placeholder = "Search for..." })
+            </li>
+            <li class="nav-item form-group">
+                @Html.LabelFor(x => x.Tags, "Filter by tags")
+                <a href="#" class="badge badge-pill badge-primary" data-toggle="tooltip" data-placement="right" title="Show only Minis with the selected tags. If no name search is specified, orders by most recently added">
+                    <span class="oi oi-info"></span>
+                </a>
+                <input id="tagsInput" class="form-control" type="text" placeholder="Find tags..." />
+                @Html.HiddenFor(x => x.Tags, new { id = "tagsValue" })
+            </li>
+            <li class="nav-item form-group form-check">
+                @Html.CheckBoxFor(x => x.FreeOnly,
+                    new
+                    {
+                        @class = "form-check-input"
+                    })
+                @Html.LabelFor(x => x.FreeOnly, "Free Minis Only",
+                    new
+                    {
+                        @class = "form-check-label"
+                    })
+            </li>
+            <li class="nav-item form-group form-check">
+                @Html.CheckBoxFor(x => x.IncludeUnapproved,
+                    new
+                    {
+                        @class = "form-check-input"
+                    })
+                @Html.LabelFor(x => x.IncludeUnapproved, "Show unapproved and untagged Minis",
+                    new
+                    {
+                        @class = "form-check-label"
+                    })
+            </li>
+            <li class="nav-item form-group">
+                <input type="submit" value="Search" class="btn btn-primary btn-block" />
+            </li>
+        </ul>
         }
         <hr/>
         <h3>Common Tags</h3>

--- a/MiniIndex/Minis/MinisController.cs
+++ b/MiniIndex/Minis/MinisController.cs
@@ -55,6 +55,7 @@ namespace MiniIndex.Minis
                                                             { "SearchString", searchRequest.SearchString },
                                                             { "Tags", String.Join(",", searchRequest.Tags) },
                                                             { "FreeOnly", searchRequest.FreeOnly.ToString() },
+                                                            { "IncludeUnapproved", searchRequest.IncludeUnapproved.ToString() },
                                                             { "HadResults", searchResult.Count>0 ? "True" : "False" },
                                                             { "PageIndex", searchRequest.PageInfo.PageIndex.ToString()}
                                                         });

--- a/MiniIndex/Pages/Admin/Index.cshtml
+++ b/MiniIndex/Pages/Admin/Index.cshtml
@@ -45,8 +45,8 @@
                             </a>
                         </td>
                         <td>
-                            <a asp-page="/Minis/UpdateStatus" asp-route-MiniID="@item.ID" asp-route-NewStatus="Approved" class="btn btn-success btn-block">
-                                Approve
+                            <a asp-page="/Minis/UpdateStatus" asp-route-MiniID="@item.ID" asp-route-NewStatus="Pending" class="btn btn-warning btn-block">
+                                Visible
                             </a>
                             <a asp-page="/Minis/UpdateStatus" asp-route-MiniID="@item.ID" asp-route-NewStatus="Rejected" class="btn btn-danger btn-block">
                                 Reject

--- a/MiniIndex/Pages/Admin/Index.cshtml.cs
+++ b/MiniIndex/Pages/Admin/Index.cshtml.cs
@@ -26,8 +26,8 @@ namespace MiniIndex.Pages.Admin
                         .Include(m => m.MiniTags)
                             .ThenInclude(mt => mt.Tag)
                         .Include(m => m.Creator)
-                        .Where(m => m.Status == Status.Pending)
-                        .OrderByDescending(m => m.MiniTags.Count())
+                        .Where(m => (m.Status == Status.Pending && m.MiniTags.Count>1) || m.Status == Status.Unindexed)
+                        .OrderByDescending(m => m.MiniTags.Count)
                         .AsNoTracking()
                         .ToListAsync();
         }

--- a/MiniIndex/Pages/Minis/Details.cshtml
+++ b/MiniIndex/Pages/Minis/Details.cshtml
@@ -23,14 +23,23 @@
                 }
 
                 <p><b>Current Status - </b>@Model.Mini.Status</p>
+                <p><b>Cost - </b>@Model.Mini.Cost</p>
+                <p><b>Thumbnail - </b>@Model.Mini.Thumbnail</p>
                 <hr />
 
                 <a asp-page="./UpdateStatus" asp-route-MiniID="@Model.Mini.ID" asp-route-NewStatus="Approved" class="btn btn-success">
                     Approve
                 </a>
+                <a asp-page="./UpdateStatus" asp-route-MiniID="@Model.Mini.ID" asp-route-NewStatus="Pending" class="btn btn-warning">
+                    Visible
+                </a>
                 <a asp-page="./UpdateStatus" asp-route-MiniID="@Model.Mini.ID" asp-route-NewStatus="Rejected" class="btn btn-danger">
                     Reject
                 </a>
+                <a asp-page="./UpdateStatus" asp-route-MiniID="@Model.Mini.ID" asp-route-NewStatus="Deleted" class="btn btn-danger">
+                    Delete
+                </a>
+                <hr />
                 <a asp-page="./FixThumbnail" asp-route-id="@Model.Mini.ID" class="btn btn-primary">
                     Fix Thumbnail
                 </a>

--- a/MiniIndex/Pages/Minis/UpdateStatus.cshtml.cs
+++ b/MiniIndex/Pages/Minis/UpdateStatus.cshtml.cs
@@ -47,12 +47,24 @@ namespace MiniIndex.Pages.Minis
                 {
                     Mini.Status = Status.Approved;
                     Mini.ApprovedTime = DateTime.Now;
-                    _context.Attach(Mini).State = EntityState.Modified; //TODO: is this needed? Change tracking should catch this...
+                    _context.Attach(Mini).State = EntityState.Modified;
+                }
+
+                if (NewStatus == "Pending")
+                {
+                    Mini.Status = Status.Pending;
+                    _context.Attach(Mini).State = EntityState.Modified;
                 }
 
                 if (NewStatus == "Rejected")
                 {
                     Mini.Status = Status.Rejected;
+                    _context.Attach(Mini).State = EntityState.Modified;
+                }
+
+                if (NewStatus == "Deleted")
+                {
+                    Mini.Status = Status.Deleted;
                     _context.Attach(Mini).State = EntityState.Modified;
                 }
 

--- a/MiniIndex/Pages/Shared/_Layout.cshtml
+++ b/MiniIndex/Pages/Shared/_Layout.cshtml
@@ -87,6 +87,8 @@
                         <div class="dropdown-divider"></div>
                         <a class="dropdown-item" href="https://github.com/aluhrs13/TheMiniIndex" target="_blank"><span class="oi oi-code"></span> View our GitHub</a>
                         <a class="dropdown-item" href="https://discordapp.com/invite/FDtYRDP" target="_blank"><span class="oi oi-chat"></span> Join us on Disord</a>
+                        <a class="dropdown-item" href="https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAANAAYEBbR1UMDNUNlVURVhEQzlFUFI5UlEwR0ZISlk5Vi4u" target="_blank"><span class="oi oi-bullhorn"></span> Give us feedback</a>
+                        
                     </div>
                 </li>
                 @if (User.IsInRole("Moderator"))

--- a/MiniIndex/wwwroot/css/site.css
+++ b/MiniIndex/wwwroot/css/site.css
@@ -44,7 +44,7 @@ a:not(.btn):not(.nav-link):not(.badge):not(.navbar-brand) {
 }
 
 .Pending {
-    background-color: #ffc107;
+    background-color: #FFF5A6;
 }
 
 .Rejected {


### PR DESCRIPTION
This'll let us mass add Minis that we know are roughly appropriate to be discovered via the string search of their name, then go back and eventually improve tagging either automatically or manually. The Minis won't show up when doing a tag search, and will be last in the list for string searches with a yellow background.

closes #156. 