### PR TITLE
Adding TagPairs and more

### DIFF
--- a/MiniIndex.Core/Minis/Search/MiniSearchRequestHandler.cs
+++ b/MiniIndex.Core/Minis/Search/MiniSearchRequestHandler.cs
@@ -48,6 +48,7 @@ namespace MiniIndex.Minis.Handlers
             {
                 search = search
                     .Where(m => m.MiniTags
+                        .Where(x => x.Status == Status.Approved)
                         .Select(x => x.Tag)
                         .Any(t => t.TagName == tag)
                     );
@@ -82,6 +83,7 @@ namespace MiniIndex.Minis.Handlers
                     {
                         tagSearch = tagSearch
                             .Where(m => m.MiniTags
+                                .Where(x => x.Status == Status.Approved)
                                 .Select(x => x.Tag)
                                 .Any(t => t.TagName == term)
                             );

--- a/MiniIndex.Models/MiniTag.cs
+++ b/MiniIndex.Models/MiniTag.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using System;
 
 namespace MiniIndex.Models
 {
@@ -10,5 +11,8 @@ namespace MiniIndex.Models
         public Tag Tag { get; set; }
         public Status Status { get; set; }
         public IdentityUser Tagger { get; set; }
+        public DateTime CreatedTime { get; set; }
+        public DateTime? ApprovedTime { get; set; }
+        public DateTime LastModifiedTime { get; set; }
     }
 }

--- a/MiniIndex.Models/Tag.cs
+++ b/MiniIndex.Models/Tag.cs
@@ -19,7 +19,9 @@ namespace MiniIndex.Models
         Location,
         OtherDescription,
         Purpose,
-        Scale
+        Scale,
+        SourceBook,
+        BookSection
     }
 
     public class Tag

--- a/MiniIndex.Models/TagPair.cs
+++ b/MiniIndex.Models/TagPair.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MiniIndex.Models
+{
+    public enum PairType
+    {
+        Synonym,
+        Parent //For Parent/Child relationships, Tag1 is the child and Tag2 is the parent.
+    }
+
+    public class TagPair
+    {
+        public TagPair()
+        {
+        }
+
+        public int ID { get; set; }
+        public Tag Tag1 { get; set; }
+        public Tag Tag2 { get; set; }
+        public PairType Type { get; set; }
+
+        public Tag GetPairedTag(Tag seedTag)
+        {
+            if(seedTag.ID == Tag1.ID)
+            {
+                return Tag2;
+            }
+            else
+            {
+                return Tag1;
+            }
+        }
+    }
+}

--- a/MiniIndex.Persistence/Migrations/20200325145807_TagPairs.Designer.cs
+++ b/MiniIndex.Persistence/Migrations/20200325145807_TagPairs.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MiniIndex.Persistence;
 
 namespace MiniIndex.Migrations
 {
     [DbContext(typeof(MiniIndexContext))]
-    partial class MiniIndexContextModelSnapshot : ModelSnapshot
+    [Migration("20200325145807_TagPairs")]
+    partial class TagPairs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MiniIndex.Persistence/Migrations/20200325145807_TagPairs.cs
+++ b/MiniIndex.Persistence/Migrations/20200325145807_TagPairs.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MiniIndex.Migrations
+{
+    public partial class TagPairs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ApprovedTime",
+                table: "MiniTag",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedTime",
+                table: "MiniTag",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastModifiedTime",
+                table: "MiniTag",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.CreateTable(
+                name: "TagPair",
+                columns: table => new
+                {
+                    ID = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Tag1ID = table.Column<int>(nullable: true),
+                    Tag2ID = table.Column<int>(nullable: true),
+                    Type = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TagPair", x => x.ID);
+                    table.ForeignKey(
+                        name: "FK_TagPair_Tag_Tag1ID",
+                        column: x => x.Tag1ID,
+                        principalTable: "Tag",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TagPair_Tag_Tag2ID",
+                        column: x => x.Tag2ID,
+                        principalTable: "Tag",
+                        principalColumn: "ID",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TagPair_Tag1ID",
+                table: "TagPair",
+                column: "Tag1ID");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TagPair_Tag2ID",
+                table: "TagPair",
+                column: "Tag2ID");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TagPair");
+
+            migrationBuilder.DropColumn(
+                name: "ApprovedTime",
+                table: "MiniTag");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedTime",
+                table: "MiniTag");
+
+            migrationBuilder.DropColumn(
+                name: "LastModifiedTime",
+                table: "MiniTag");
+        }
+    }
+}

--- a/MiniIndex.Persistence/MiniIndexContext.cs
+++ b/MiniIndex.Persistence/MiniIndexContext.cs
@@ -15,6 +15,7 @@ namespace MiniIndex.Persistence
         public DbSet<Tag> Tag { get; set; }
         public DbSet<MiniTag> MiniTag { get; set; }
         public DbSet<Starred> Starred { get; set; }
+        public DbSet<TagPair> TagPair { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/MiniIndex/Areas/Identity/Pages/_ValidationScriptsPartial.cshtml
+++ b/MiniIndex/Areas/Identity/Pages/_ValidationScriptsPartial.cshtml
@@ -1,1 +1,7 @@
-﻿<script type="module" src="https://miniindex.azureedge.net/validation.entry.js" defer></script>
+﻿<environment include="Development">
+    <script type="module" src="~/dist/validation.entry.js" defer></script>
+</environment>
+
+<environment exclude="Development">
+    <script type="module" src="https://miniindex.azureedge.net/validation.entry.js" defer></script>
+</environment>

--- a/MiniIndex/Minis/BrowseMinis.cshtml
+++ b/MiniIndex/Minis/BrowseMinis.cshtml
@@ -15,8 +15,17 @@
 
 @section Scripts
 {
-    <script type="module" src="https://miniindex.azureedge.net/tags.entry.js" defer></script>
-    <link rel="stylesheet" href="https://miniindex.azureedge.net/tags.css">
+
+    <environment include="Development">
+        <script type="module" src="~/dist/tags.entry.js" defer></script>
+        <link rel="stylesheet" href="~/dist/tags.css">
+    </environment>
+
+    <environment exclude="Development">
+        <script type="module" src="https://miniindex.azureedge.net/tags.entry.js" defer></script>
+        <link rel="stylesheet" href="https://miniindex.azureedge.net/tags.css">
+    </environment>
+
 }
 
 <div class="container-fluid">
@@ -38,12 +47,12 @@
                     <div class="card shadow">
                         <div class="card-body">
                             <h2 class="card-title">Happy with your search results?</h2>
-                               Please take a second to <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAANAAYEBbR1URTIxTVpVOVdBUDFHUkhHR1RFT1RGSzZSSi4u">rate the results</a> below and give us any feedback.
+                            Please take a second to <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAANAAYEBbR1URTIxTVpVOVdBUDFHUkhHR1RFT1RGSzZSSi4u">rate the results</a> below and give us any feedback.
                         </div>
                     </div>
                 }
             </div>
-            <br/>
+            <br />
             @if (String.IsNullOrWhiteSpace(Model.SearchModel.SearchString))
             {
                 <h2>Most Recent Results</h2>
@@ -85,5 +94,5 @@
                 }
             </div>
         </div>
-    </div> 
+    </div>
 </div>

--- a/MiniIndex/Minis/MiniListView.cshtml
+++ b/MiniIndex/Minis/MiniListView.cshtml
@@ -1,5 +1,7 @@
 ﻿@using MiniIndex.Models
 @using MiniIndex.Core.Pagination
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
 
 @model PaginatedList<Mini>
 
@@ -48,12 +50,12 @@
                         <a href="/Minis/Details?id=@mini.ID">
                             @if (mini.Thumbnail.Contains("miniindex.blob.core.windows.net/"))
                             {
-                                <img class="card-img-top" src="@mini.Thumbnail.Replace("miniindex.blob.core.windows.net", "miniindexblobcdn.azureedge.net")" width="314" height="236" />
+                                <img class="card-img-top" src="@mini.Thumbnail.Replace("miniindex.blob.core.windows.net", Configuration["CDNURL"]+".azureedge.net")" width="314" height="236" />
                             }
                             else
                             {
                                 <img class="card-img-top" src="@mini.Thumbnail" width="314" height="236" />
-                            }                            
+                            }
                             <span></span>
                         </a>
                     </div>
@@ -79,5 +81,5 @@
             @:</div>
         }
         </div>
-        </div>
+    </div>
 </div>

--- a/MiniIndex/Pages/Admin/CategoryManager.cshtml
+++ b/MiniIndex/Pages/Admin/CategoryManager.cshtml
@@ -8,7 +8,13 @@
 
 @section Scripts
 {
-    <script type="module" src="https://miniindex.azureedge.net/stars.entry.js" defer></script>
+    <environment include="Development">
+        <script type="module" src="~/dist/stars.entry.js" defer></script>
+    </environment>
+
+    <environment exclude="Development">
+        <script type="module" src="https://miniindex.azureedge.net/stars.entry.js" defer></script>
+    </environment>
 }
 
 @if (User.IsInRole("Moderator"))

--- a/MiniIndex/Pages/Admin/CategoryManager.cshtml
+++ b/MiniIndex/Pages/Admin/CategoryManager.cshtml
@@ -25,11 +25,8 @@
         <thead>
             <tr>
                 <th>Tag Name</th>
-                <th>Tag Category</th>
-                <th>ID</th>
                 <th>Count</th>
                 <th>View Tagged Minis</th>
-                <th>Delete Tag</th>
             </tr>
         </thead>
         <tbody>
@@ -37,24 +34,15 @@
             {
                 <tr id="@item.Key.ID">
                     <td>
-                        @Html.DisplayFor(modelItem => item.Key.TagName)
-                    </td>
-                    <td>
-                        <select asp-for="@item.Key.Category" asp-items="Html.GetEnumSelectList<MiniIndex.Models.TagCategory>().OrderBy(m => m.Text)" class="change-category">
-                            <option selected="selected" value=""></option>
-                        </select>
-                    </td>
-                    <td>
-                        @item.Key.ID
+                        <a href="/Tags/Manage?id=@item.Key.ID">
+                            @Html.DisplayFor(modelItem => item.Key.TagName)
+                        </a>
                     </td>
                     <td>
                         @item.Count()
                     </td>
                     <td>
                         <a href="/Minis/?Tags=@item.Key.TagName">View Minis</a>
-                    </td>
-                    <td>
-                        <a href="/Tags/Delete?id=@item.Key.ID">Delete Tag</a>
                     </td>
                 </tr>
             }

--- a/MiniIndex/Pages/Admin/Index.cshtml
+++ b/MiniIndex/Pages/Admin/Index.cshtml
@@ -46,7 +46,7 @@
                             @item.Sources.First().Site.DisplayName
                         </td>
                         <td>
-                            <a asp-page="/Minis/Details" asp-route-id="@item.ID">
+                            <a asp-page="/Minis/Edit" asp-route-id="@item.ID">
                                 @item.Name
                             </a>
                         </td>

--- a/MiniIndex/Pages/Admin/ManageNavPages.cs
+++ b/MiniIndex/Pages/Admin/ManageNavPages.cs
@@ -13,6 +13,8 @@ namespace MiniIndex.Pages.Admin
         public static string Users => "Users";
         public static string Creators => "Creators";
         public static string TagStream => "TagStream";
+        public static string TagPairs => "TagPairs";
+
 
 
         public static string MinisNavClass(ViewContext viewContext) => PageNavClass(viewContext, Minis);
@@ -20,6 +22,8 @@ namespace MiniIndex.Pages.Admin
         public static string UsersNavClass(ViewContext viewContext) => PageNavClass(viewContext, Users);
         public static string CreatorsNavClass(ViewContext viewContext) => PageNavClass(viewContext, Creators);
         public static string TagStreamNavClass(ViewContext viewContext) => PageNavClass(viewContext, TagStream);
+        public static string TagPairsNavClass(ViewContext viewContext) => PageNavClass(viewContext, TagPairs);
+
 
 
         private static string PageNavClass(ViewContext viewContext, string page)

--- a/MiniIndex/Pages/Admin/TagPairManager.cshtml
+++ b/MiniIndex/Pages/Admin/TagPairManager.cshtml
@@ -1,0 +1,72 @@
+﻿@page
+@model MiniIndex.Pages.Admin.TagPairManagerModel
+
+@{
+    ViewData["Title"] = "Tag Manager";
+    ViewData["ActivePage"] = ManageNavPages.TagPairs;
+}
+
+@section Scripts
+{
+    <environment include="Development">
+    </environment>
+
+    <environment exclude="Development">
+    </environment>
+}
+
+@if (User.IsInRole("Moderator"))
+{
+    <h4>Tag Pairs</h4>
+
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Tag 1</th>
+                <th>Type</th>
+                <th>Tag 2</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>
+                    <select>
+                        <option selected="selected" value=""></option>
+                    </select>
+                </td>
+                <td>
+                    <select asp-items="Html.GetEnumSelectList<MiniIndex.Models.PairType>().OrderBy(m => m.Text)">
+                        <option selected="selected" value=""></option>
+                    </select>
+                </td>
+                <td>
+                    <select>
+                        <option selected="selected" value=""></option>
+                    </select>
+                </td>
+                <td>
+                    <a href="#" id="addPair" class="btn btn-success btn-block">Add</a>
+                </td>
+            </tr>
+
+            @foreach (var item in Model.TagPairs)
+            {
+                <tr id="@item.ID">
+                    <td>
+                        @Html.DisplayFor(modelItem => item.Tag1.TagName)
+                    </td>
+                    <td>
+                        @Html.DisplayFor(modelItem => item.Type)
+                    </td>
+                    <td>
+                        @Html.DisplayFor(modelItem => item.Tag2.TagName)
+                    </td>
+                    <td>
+                        <a href="#" id="@item.ID" class="btn btn-danger btn-block removePair">Remove</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}

--- a/MiniIndex/Pages/Admin/TagPairManager.cshtml.cs
+++ b/MiniIndex/Pages/Admin/TagPairManager.cshtml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using MiniIndex.Models;
+using MiniIndex.Persistence;
+
+namespace MiniIndex.Pages.Admin
+{
+    [Authorize]
+    public class TagPairManagerModel : PageModel
+    {
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly SignInManager<IdentityUser> _signInManager;
+        private readonly MiniIndexContext _context;
+        public IList<TagPair> TagPairs { get; set; }
+
+        public TagPairManagerModel(
+                UserManager<IdentityUser> userManager,
+                SignInManager<IdentityUser> signInManager,
+                MiniIndexContext context)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _context = context;
+        }
+
+        public async Task OnGetAsync()
+        {
+            if (User.IsInRole("Moderator"))
+            {
+                TagPairs = _context.TagPair
+                                .Include(tp => tp.Tag1)
+                                .Include(tp => tp.Tag2)
+                                .ToList();
+            }
+        }
+    }
+}

--- a/MiniIndex/Pages/Admin/TagStream.cshtml
+++ b/MiniIndex/Pages/Admin/TagStream.cshtml
@@ -14,13 +14,19 @@
         <thead>
             <tr>
                 <th>
-                    UserName
+
                 </th>
                 <th>
-                    MiniCount
+                    Tag
                 </th>
                 <th>
-                    TagCount
+                    Mini Name
+                </th>
+                <th>
+                    Tagger
+                </th>
+                <th>
+
                 </th>
             </tr>
         </thead>
@@ -34,20 +40,30 @@
                 else
                 {
                     @:<tr>
-                }
-                        <td>
-                            <img src="@Html.DisplayFor(modelItem => item.Mini.Thumbnail)" width="64" />
-                        </td>
-                        <td>
-                            @item.Tagger.UserName
-                        </td>
-                        <td>
-                            @item.Mini.Name
-                        </td>
-                        <td>
-                            @item.Tag.TagName
-                        </td>
-                    @:</tr>
+}
+                <td>
+                    <a asp-page="/MiniTags/UpdateStatus" asp-route-MiniID="@item.MiniID" asp-route-TagID="@item.TagID" asp-route-NewStatus="Approved" class="btn btn-success btn-block">
+                        Approve
+                    </a>
+                    <a asp-page="/MiniTags/UpdateStatus" asp-route-MiniID="@item.MiniID" asp-route-TagID="@item.TagID" asp-route-NewStatus="Rejected" class="btn btn-danger btn-block">
+                        Reject
+                    </a>
+                </td>
+                <td>
+                    <img src="@Html.DisplayFor(modelItem => item.Mini.Thumbnail)" width="64" />
+                </td>
+                <td>
+                    @item.Tag.TagName
+                </td>
+                <td>
+                    <a asp-page="/Minis/Details" asp-route-id="@item.Mini.ID">
+                        @item.Mini.Name
+                    </a>
+                </td>
+                <td>
+                    @item.Tagger.UserName
+                </td>
+            @:</tr>
                 }
             </tbody>
     </table>

--- a/MiniIndex/Pages/Admin/TagStream.cshtml
+++ b/MiniIndex/Pages/Admin/TagStream.cshtml
@@ -56,7 +56,7 @@
                     @item.Tag.TagName
                 </td>
                 <td>
-                    <a asp-page="/Minis/Details" asp-route-id="@item.Mini.ID">
+                    <a asp-page="/Minis/Edit" asp-route-id="@item.Mini.ID">
                         @item.Mini.Name
                     </a>
                 </td>

--- a/MiniIndex/Pages/Admin/TagStream.cshtml.cs
+++ b/MiniIndex/Pages/Admin/TagStream.cshtml.cs
@@ -25,12 +25,13 @@ namespace MiniIndex.Pages.TagStream
         {
             UserTags = _context.MiniTag
                 .Include(mt => mt.Tagger)
-                .Include(mt=>mt.Mini)
-                .Include(mt=>mt.Tag)
-                .Where(mt=>mt.Tagger!=null)
+                .Include(mt => mt.Mini)
+                .Include(mt => mt.Tag)
+                .Where(mt => mt.Status == Status.Pending)
+                .Where(mt => mt.Tagger != null)
                 .ToList();
 
-            UserTags = UserTags.Take(100).ToList();
+            UserTags = UserTags.ToList();
         }
     }
 }

--- a/MiniIndex/Pages/Admin/_ManageNav.cshtml
+++ b/MiniIndex/Pages/Admin/_ManageNav.cshtml
@@ -4,5 +4,5 @@
     <li class="nav-item"><a class="nav-link @ManageNavPages.UsersNavClass(ViewContext)" id="users" asp-page="./ManageUsers">Manage Users</a></li>
     <li class="nav-item"><a class="nav-link @ManageNavPages.CreatorsNavClass(ViewContext)" id="creators" asp-page="./ManageCreators">Manage Creators</a></li>
     <li class="nav-item"><a class="nav-link @ManageNavPages.TagStreamNavClass(ViewContext)" id="tagStream" asp-page="./TagStream">Tag Stream</a></li>
-
+    <li class="nav-item"><a class="nav-link @ManageNavPages.TagPairsNavClass(ViewContext)" id="tagPairs" asp-page="./TagPairManager">Tag Pairs</a></li>
 </ul>

--- a/MiniIndex/Pages/Creators/Details.cshtml
+++ b/MiniIndex/Pages/Creators/Details.cshtml
@@ -121,7 +121,7 @@
                                     <hr />
                                     @if (item.Status == Models.Status.Approved)
                                     {
-                                        <a asp-page="/Minis/Details" asp-route-id="@item.ID" class="btn btn-sm btn-outline-primary">Already indexed </a>
+                                        <a asp-page="/Minis/Edit" asp-route-id="@item.ID" class="btn btn-sm btn-outline-primary">Already indexed </a>
                                     }
                                     else if (item.Status == Models.Status.Pending)
                                     {

--- a/MiniIndex/Pages/Creators/Details.cshtml
+++ b/MiniIndex/Pages/Creators/Details.cshtml
@@ -1,5 +1,7 @@
 ﻿@page
 @using MiniIndex.Models
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
 
 @model MiniIndex.Pages.Creators.DetailsModel
 
@@ -57,7 +59,7 @@
                                 <a href="/Minis/Details?id=@mini.ID">
                                     @if (mini.Thumbnail.Contains("miniindex.blob.core.windows.net/"))
                                     {
-                                        <img class="card-img-top" src="@mini.Thumbnail.Replace("miniindex.blob.core.windows.net", "miniindexblobcdn.azureedge.net")" width="314" height="236" />
+                                        <img class="card-img-top" src="@mini.Thumbnail.Replace("miniindex.blob.core.windows.net", Configuration["CDNURL"]+".azureedge.net")" width="314" height="236" />
                                     }
                                     else
                                     {
@@ -96,7 +98,7 @@
 
     </div>
     <div class="tab-pane" id="thingiverse" role="tabpanel" aria-labelledby="thingiverse-tab">
-        @if (Model.Creator.Sites.Any(s => s is MiniIndex.Models.SourceSites.ThingiverseSource) && Model.ThingiverseMiniList.Count>0)
+        @if (Model.Creator.Sites.Any(s => s is MiniIndex.Models.SourceSites.ThingiverseSource) && Model.ThingiverseMiniList.Count > 0)
         {
             <div class="album py-5 bg-light">
                 <div class="container">
@@ -159,8 +161,8 @@
         }
         @if (!String.IsNullOrEmpty(Model.ThingiverseError))
         {
-            <br/>
-            <h3 align ="center" style="margin:40px;">@Model.ThingiverseError</h3>
+            <br />
+            <h3 align="center" style="margin:40px;">@Model.ThingiverseError</h3>
         }
     </div>
 </div>

--- a/MiniIndex/Pages/Index.cshtml
+++ b/MiniIndex/Pages/Index.cshtml
@@ -1,5 +1,8 @@
 ﻿@page
 @model IndexModel
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
+
 @{
     ViewData["Title"] = "The Mini Index";
 }
@@ -48,7 +51,7 @@
                         <a href="/Minis/Details?id=@mini.ID">
                             @if (mini.Thumbnail.Contains("miniindex.blob.core.windows.net/"))
                             {
-                                <img class="card-img-top" src="@mini.Thumbnail.Replace("miniindex.blob.core.windows.net", "miniindexblobcdn.azureedge.net")" width="314" height="236" />
+                                <img class="card-img-top" src="@mini.Thumbnail.Replace("miniindex.blob.core.windows.net", Configuration["CDNURL"]+".azureedge.net")" width="314" height="236" />
                             }
                             else
                             {

--- a/MiniIndex/Pages/MiniTags/Create.cshtml.cs
+++ b/MiniIndex/Pages/MiniTags/Create.cshtml.cs
@@ -128,11 +128,21 @@ namespace MiniIndex.Pages.MiniTags
                 tag.MiniTags.Add(newMiniTag);
                 mini.MiniTags.Add(newMiniTag);
                 _context.MiniTag.Add(newMiniTag);
+            }
+            else
+            {
+                newMiniTag = mini.MiniTags.Where(mt => mt.Tag.TagName == tag.TagName).First();
 
-                foreach (Tag pairedTag in FindPairedTags(tag))
+                if(newMiniTag.Status == Status.Pending || newMiniTag.Status == Status.Approved)
                 {
-                    AddMiniTag(mini, pairedTag, user);
+                    return;
                 }
+                newMiniTag.Status = Status.Pending;
+            }
+
+            foreach (Tag pairedTag in FindPairedTags(tag))
+            {
+                AddMiniTag(mini, pairedTag, user);
             }
         }
 

--- a/MiniIndex/Pages/MiniTags/Create.cshtml.cs
+++ b/MiniIndex/Pages/MiniTags/Create.cshtml.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using MiniIndex.Models;
 using MiniIndex.Persistence;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -49,59 +50,37 @@ namespace MiniIndex.Pages.MiniTags
                 return Page();
             }
 
-            MiniTag newMiniTag = new MiniTag();
+            IdentityUser user = await _userManager.GetUserAsync(User);
+
             Tag newTag = new Tag();
 
-            IdentityUser user = await _userManager.GetUserAsync(User);
-            newMiniTag.Tagger = user;
-
+            //MiniTags can be created by passing a tagName or an ID.
             if (!String.IsNullOrEmpty(tagName))
             {
-                //Need to make a new tag, go by name.
-                Tag newNewTag = new Tag
-                {
-                    TagName = tagName
-                };
-
-                if (!_context.Tag.Any(m => m.TagName == newNewTag.TagName))
-                {
-                    _context.Tag.Add(newNewTag);
-                    await _context.SaveChangesAsync();
-                }
-
-                newTag = _context.Tag.Where(t => t.TagName == tagName)
-                            .Include(m => m.MiniTags)
-                            .First();
-
-                newMiniTag.TagID = newTag.ID;
+                newTag = await AddAndFindTagByName(tagName);
             }
             else
             {
-                //Don't need to make a new tag, go by ID.
+                //Don't need to make a new tag, select the existing tag
                 newTag = _context.Tag.Where(t => t.ID == Int32.Parse(tag))
                                 .Include(m => m.MiniTags)
                                 .First();
-
-                newMiniTag.TagID = Int32.Parse(tag);
             }
-            newMiniTag.Tag = newTag;
-            newMiniTag.MiniID = Int32.Parse(mini);
 
-            Mini newMini = _context.Mini.Where(m => m.ID == newMiniTag.MiniID)
-                .Include(m => m.Creator)
-                .Include(m => m.MiniTags)
-                    .ThenInclude(mt => mt.Tag)
-                .First();
+            Mini newMini = _context.Mini.Where(m => m.ID == Int32.Parse(mini))
+                            .Include(m => m.Creator)
+                            .Include(m => m.MiniTags)
+                                .ThenInclude(mt => mt.Tag)
+                            .First();
 
-            newMiniTag.Mini = newMini;
-            newTag.MiniTags.Add(newMiniTag);
+            AddMiniTag(newMini, newTag, user);
 
-            if (!newMini.MiniTags.Where(mt => mt.Tag.TagName == newTag.TagName).Any())
+            //TODO - If this breaks because the tag structure is too complicated serialize the adding of MiniTags by moving the SaveChanges into the function and await each AddMiniTag.
+            foreach(Tag pairedTag in FindPairedTags(newTag))
             {
-                newMini.MiniTags.Add(newMiniTag);
-                _context.MiniTag.Add(newMiniTag);
-                await _context.SaveChangesAsync();
+                AddMiniTag(newMini, pairedTag, user);
             }
+            await _context.SaveChangesAsync();
 
             return Page();
         }
@@ -109,6 +88,72 @@ namespace MiniIndex.Pages.MiniTags
         public async Task<IActionResult> OnPostAsync()
         {
             return RedirectToPage("./Index");
+        }
+
+        public async Task<Tag> AddAndFindTagByName(string tagName)
+        {
+            Tag newNewTag = new Tag
+            {
+                TagName = tagName
+            };
+
+            //Create the tag
+            if (!_context.Tag.Any(m => m.TagName == newNewTag.TagName))
+            {
+                _context.Tag.Add(newNewTag);
+                await _context.SaveChangesAsync();
+            }
+
+            return _context.Tag.Where(t => t.TagName == tagName)
+                        .Include(m => m.MiniTags)
+                        .First();
+        }
+
+        public async void AddMiniTag(Mini mini, Tag tag, IdentityUser user)
+        {
+            MiniTag newMiniTag = new MiniTag()
+            {
+                Mini = mini,
+                MiniID = mini.ID,
+                Tag = tag,
+                TagID = tag.ID,
+                Tagger = user,
+                Status = Status.Pending,
+                CreatedTime = DateTime.Now,
+                LastModifiedTime = DateTime.Now
+            };
+
+            if (!mini.MiniTags.Where(mt => mt.Tag.TagName == tag.TagName).Any())
+            {
+                tag.MiniTags.Add(newMiniTag);
+                mini.MiniTags.Add(newMiniTag);
+                _context.MiniTag.Add(newMiniTag);
+
+                foreach (Tag pairedTag in FindPairedTags(tag))
+                {
+                    AddMiniTag(mini, pairedTag, user);
+                }
+            }
+        }
+
+        public IList<Tag> FindPairedTags(Tag seedTag)
+        {
+            IList<Tag> synonyms = _context.TagPair
+                                        .Include(tp => tp.Tag1)
+                                        .Include(tp => tp.Tag2)
+                                    .Where(tp => tp.Type == PairType.Synonym && (tp.Tag1 == seedTag || tp.Tag2 == seedTag))
+                                    .Select(tp => tp.GetPairedTag(seedTag))
+                                    .ToList();
+
+            IList<Tag> parents = _context.TagPair
+                                        .Include(tp => tp.Tag1)
+                                        .Include(tp => tp.Tag2)
+                                    .Where(tp => tp.Type == PairType.Parent && tp.Tag1 == seedTag)
+                                    .Select(tp => tp.GetPairedTag(tp.Tag1))
+                                    .ToList();
+
+            return synonyms.Concat(parents).ToList();
+
         }
     }
 }

--- a/MiniIndex/Pages/MiniTags/Delete.cshtml.cs
+++ b/MiniIndex/Pages/MiniTags/Delete.cshtml.cs
@@ -39,8 +39,10 @@ namespace MiniIndex.Pages.MiniTags
 
             MiniTag = await _context.MiniTag.FindAsync(MiniID, TagID);
 
-            _context.MiniTag.Remove(MiniTag);
-                await _context.SaveChangesAsync();
+            MiniTag.Status = Status.Deleted;
+            MiniTag.LastModifiedTime = DateTime.Now;
+
+            await _context.SaveChangesAsync();
 
             return Page();
         }
@@ -56,7 +58,9 @@ namespace MiniIndex.Pages.MiniTags
 
             if (MiniTag != null)
             {
-                _context.MiniTag.Remove(MiniTag);
+                MiniTag.Status = Status.Deleted;
+                MiniTag.LastModifiedTime = DateTime.Now;
+
                 await _context.SaveChangesAsync();
             }
 

--- a/MiniIndex/Pages/MiniTags/UpdateStatus.cshtml
+++ b/MiniIndex/Pages/MiniTags/UpdateStatus.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model MiniIndex.Pages.MiniTags.UpdateStatusModel
+@{
+}

--- a/MiniIndex/Pages/MiniTags/UpdateStatus.cshtml.cs
+++ b/MiniIndex/Pages/MiniTags/UpdateStatus.cshtml.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using MiniIndex.Models;
+using MiniIndex.Persistence;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MiniIndex.Pages.MiniTags
+{
+    public class UpdateStatusModel : PageModel
+    {
+        public UpdateStatusModel(MiniIndexContext context)
+        {
+            _context = context;
+        }
+
+        private readonly MiniIndexContext _context;
+
+        [BindProperty(SupportsGet = true)]
+        public int? MiniID { get; set; }
+        
+        [BindProperty(SupportsGet = true)]
+        public int? TagID { get; set; }
+
+        [BindProperty(SupportsGet = true)]
+        public string NewStatus { get; set; }
+
+
+        [BindProperty]
+        public MiniTag MiniTag { get; set; }
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            if (User.IsInRole("Moderator"))
+            {
+                if (TagID == null || MiniID == null || NewStatus == null)
+                {
+                    return NotFound();
+                }
+
+                MiniTag = await _context.MiniTag.FirstOrDefaultAsync(m => m.MiniID == MiniID && m.TagID == TagID);
+
+                if (MiniTag == null)
+                {
+                    return NotFound();
+                }
+
+                if (NewStatus == "Approved")
+                {
+                    MiniTag.Status = Status.Approved;
+                    MiniTag.ApprovedTime = DateTime.Now;
+                    MiniTag.LastModifiedTime = DateTime.Now;
+                    _context.Attach(MiniTag).State = EntityState.Modified;
+                }
+
+                if (NewStatus == "Pending")
+                {
+                    MiniTag.Status = Status.Pending;
+                    MiniTag.LastModifiedTime = DateTime.Now;
+                    _context.Attach(MiniTag).State = EntityState.Modified;
+                }
+
+                if (NewStatus == "Rejected")
+                {
+                    MiniTag.Status = Status.Rejected;
+                    MiniTag.LastModifiedTime = DateTime.Now;
+                    _context.Attach(MiniTag).State = EntityState.Modified;
+                }
+
+                try
+                {
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+
+                }
+
+                return RedirectToPage("/Admin/TagStream");
+                
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+    }
+}

--- a/MiniIndex/Pages/Minis/Create.cshtml
+++ b/MiniIndex/Pages/Minis/Create.cshtml
@@ -2,6 +2,8 @@
 @model MiniIndex.Pages.Minis.CreateModel
 @inject SignInManager<IdentityUser> SignInManager
 @inject MiniIndex.Core.CoreServiceInfo serviceInfo
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
 
 @{
     ViewData["Title"] = "Create";
@@ -10,13 +12,22 @@
 @if (SignInManager.IsSignedIn(User))
 {
     <div class="container" style="padding:50px;">
+        @if (Configuration["CreateWarningMessage"] != "")
+        {
+            <div class="alert alert-danger shadow-sm">
+                    <h2>Warning</h2>
+                    <p>
+                        @Configuration["CreateWarningMessage"];
+                    </p>
+            </div>
+        }
         <div class="row">
             <div class="colo-md-12">
                 <h1>
                     Add a mini
                 </h1>
                 <p font-size="smaller">
-                    Thank you for submitting a mini! Just paste a link to a Thingiverse, Shapeways, or Gumroad model below to get started. Please make sure you take a few seconds once completed to add some useful tags.
+                    Thank you for submitting a mini! Just paste a link to a model on one of our supported sites below to get started. Please make sure you take a few seconds once completed to add some useful tags.
                 </p>
             </div>
         </div>

--- a/MiniIndex/Pages/Minis/Create.cshtml.cs
+++ b/MiniIndex/Pages/Minis/Create.cshtml.cs
@@ -62,7 +62,7 @@ namespace MiniIndex.Pages.Minis
                 return Page();
             }
 
-            return RedirectToPage("./Details", new { id = mini.ID, showHelp = "create" });
+            return RedirectToPage("./Edit", new { id = mini.ID, showHelp = "create" });
         }
     }
 }

--- a/MiniIndex/Pages/Minis/Details.cshtml
+++ b/MiniIndex/Pages/Minis/Details.cshtml
@@ -154,11 +154,11 @@
                     {
                         @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
                         {
-                            <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <b>@MiniTag.Tag.TagName</b></a>
+                            <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <b>@MiniTag.Tag.TagName (@MiniTag.Status.ToString())</b></a>
                         }
                         else
                         {
-                            <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <small>@MiniTag.Tag.Category:</small> <b>@MiniTag.Tag.TagName</b></a>
+                            <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <small>@MiniTag.Tag.Category:</small> <b>@MiniTag.Tag.TagName (@MiniTag.Status.ToString())</b></a>
                         }
 
                     }

--- a/MiniIndex/Pages/Minis/Details.cshtml
+++ b/MiniIndex/Pages/Minis/Details.cshtml
@@ -8,7 +8,13 @@
 
 @section Scripts
 {
-    <script type="module" src="https://miniindex.azureedge.net/stars.entry.js" defer></script>
+    <environment include="Development">
+        <script type="module" src="~/dist/stars.entry.js" defer></script>
+    </environment>
+
+    <environment exclude="Development">
+        <script type="module" src="https://miniindex.azureedge.net/stars.entry.js" defer></script>
+    </environment>
 }
 
 <div>
@@ -83,7 +89,7 @@
                 }
             </div>
         </div>
-        <br/>
+        <br />
     }
 
     <h2>@Html.DisplayFor(model => model.Mini.Name) by <a href="/Creators/Details?id=@Model.Mini.Creator.ID">@Html.DisplayFor(model => model.Mini.Creator.Name)</a></h2>
@@ -124,14 +130,14 @@
 
             <hr />
 
-                @if (Model.Mini.Thumbnail.Contains("miniindex.blob.core.windows.net/"))
-                {
-                    <img class="img-fluid rounded" src="@Model.Mini.Thumbnail.Replace("miniindex.blob.core.windows.net", "miniindexblobcdn.azureedge.net")" />
-                }
-                else
-                {
-                    <img class="img-fluid rounded" src="@Model.Mini.Thumbnail" />
-                }
+            @if (Model.Mini.Thumbnail.Contains("miniindex.blob.core.windows.net/"))
+            {
+                <img class="img-fluid rounded" src="@Model.Mini.Thumbnail.Replace("miniindex.blob.core.windows.net", "miniindexblobcdn.azureedge.net")" />
+            }
+            else
+            {
+                <img class="img-fluid rounded" src="@Model.Mini.Thumbnail" />
+            }
         </div>
 
         <div class="col-md-6">
@@ -223,11 +229,11 @@
                     <div class="add-tag-div">
 
                         @foreach (var Tag in Model.UnusedTags
-                        .Where(m => !string.IsNullOrEmpty(m.Category.ToString())
-                            && m.Category != TagCategory.Genre
-                            && m.Category != TagCategory.OtherDescription
-                            && m.Category != TagCategory.CreatureName
-                            && m.Category != TagCategory.Use))
+                       .Where(m => !string.IsNullOrEmpty(m.Category.ToString())
+                           && m.Category != TagCategory.Genre
+                           && m.Category != TagCategory.OtherDescription
+                           && m.Category != TagCategory.CreatureName
+                           && m.Category != TagCategory.Use))
                         {
                             @if (Tag.Category.ToString() != PreviousCategory)
                             {

--- a/MiniIndex/Pages/Minis/Details.cshtml
+++ b/MiniIndex/Pages/Minis/Details.cshtml
@@ -2,6 +2,8 @@
 @using MiniIndex.Models;
 @model MiniIndex.Pages.Minis.DetailsModel
 @inject SignInManager<IdentityUser> SignInManager
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
 @{
     ViewData["Title"] = "Details";
 }
@@ -104,7 +106,7 @@
 
             @if (Model.Mini.Thumbnail.Contains("miniindex.blob.core.windows.net/"))
             {
-                <img class="img-fluid rounded" src="@Model.Mini.Thumbnail.Replace("miniindex.blob.core.windows.net", "miniindexblobcdn.azureedge.net")" />
+                <img class="img-fluid rounded" src="@Model.Mini.Thumbnail.Replace("miniindex.blob.core.windows.net", Configuration["CDNURL"]+".azureedge.net")" />
             }
             else
             {
@@ -117,7 +119,7 @@
             <small>
                 Something look wrong? <a asp-page="./Edit" asp-route-id="@Model.Mini.ID">Tag this Mini</a>
             </small>
-            <hr/>
+            <hr />
             @foreach (var MiniTag in Model.Mini.MiniTags.Where(mt => mt.Status == Status.Approved))
             {
                 @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
@@ -141,7 +143,7 @@
         </div>
 
         <div class="col-md-6">
-            
+
         </div>
     </div>
 </div>

--- a/MiniIndex/Pages/Minis/Details.cshtml
+++ b/MiniIndex/Pages/Minis/Details.cshtml
@@ -56,47 +56,19 @@
 
 <div class="container">
     <p id="miniid" style="display:none;">@Model.Mini.ID</p>
+
     <div>
         <a asp-page="./">Back to List</a>
     </div>
 
-    @if (!String.IsNullOrEmpty(Model.ShowHelp))
-    {
-        <div class="card shadow-sm">
-            <div class="card-body">
-                <h2 class="card-title">Tag Guidance</h2>
-                <p>
-                    <b>Thanks for contributing to The Mini Index!</b><br />
-                    We have some guidelines written about how to make your
-                    tags great, please read through them <a href="https://github.com/aluhrs13/TheMiniIndex/wiki/How-to-tag-Minis">here.</a> At a minimum, please make sure you include
-                    the genre, use, and any notable descriptions like the creature's name and type or race and gender.
-                    Your Mini will show up once a moderator gets a chance to look and approve it.
-                </p>
-                @if (Model.ShowHelp == "create")
-                {
-                    <p>If you're submitting a bunch of Minis from a single creator, we'll approve at most a few a day to not flood the front page with a single creator.</p>
-                    <a href="/Minis/Create" class="btn btn-primary">Add another Mini</a>
-                    <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAANAAYEBbR1URVo3SDNGWTlENU5FNkw3VjRaNVJPVkVDRy4u" target="_blank" class="btn btn-secondary">
-                        Something doesn't look right
-                    </a>
-                }
-                @if (Model.ShowHelp == "tag")
-                {
-                    <a href="/Minis/Help" class="btn btn-primary">Tag another Mini</a>
-                    <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAANAAYEBbR1URVo3SDNGWTlENU5FNkw3VjRaNVJPVkVDRy4u" target="_blank" class="btn btn-secondary">
-                        Something's wrong
-                    </a>
-                }
-            </div>
-        </div>
-        <br />
-    }
+    <h2>
+        @Html.DisplayFor(model => model.Mini.Name) by <a href="/Creators/Details?id=@Model.Mini.Creator.ID">@Html.DisplayFor(model => model.Mini.Creator.Name)</a>
+    </h2>
 
-    <h2>@Html.DisplayFor(model => model.Mini.Name) by <a href="/Creators/Details?id=@Model.Mini.Creator.ID">@Html.DisplayFor(model => model.Mini.Creator.Name)</a></h2>
     <hr />
 
     <div class="row">
-        <div class="col-md-4" align="center">
+        <div class="col-md-6" align="center">
             <div class="row">
                 <div class="col-md-8">
                     @if (Model.Mini.Sources.Any())
@@ -142,133 +114,34 @@
 
         <div class="col-md-6">
             <h3>Tags</h3>
-            @if (!SignInManager.IsSignedIn(User))
+            <small>
+                Something look wrong? <a asp-page="./Edit" asp-route-id="@Model.Mini.ID">Tag this Mini</a>
+            </small>
+            <hr/>
+            @foreach (var MiniTag in Model.Mini.MiniTags.Where(mt => mt.Status == Status.Approved))
             {
-                <p><strong><a href="/Identity/Account/Login?ReturnUrl=@HttpContext.Request.Path@HttpContext.Request.QueryString">Register</a> an account or <a href="/Identity/Account/Login?ReturnUrl=@HttpContext.Request.Path@HttpContext.Request.QueryString">login</a> to add or remove tags.</strong></p>
-            }
-            <div id="UsedTags">
-                @foreach (var MiniTag in Model.Mini.MiniTags)
+                @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
                 {
-
-                    @if (SignInManager.IsSignedIn(User))
-                    {
-                        @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
-                        {
-                            <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <b>@MiniTag.Tag.TagName (@MiniTag.Status.ToString())</b></a>
-                        }
-                        else
-                        {
-                            <a href="#" id="@MiniTag.Tag.ID" class="btn btn-outline-danger remove-tag" style="margin-top:5px;">- <small>@MiniTag.Tag.Category:</small> <b>@MiniTag.Tag.TagName (@MiniTag.Status.ToString())</b></a>
-                        }
-
-                    }
-                    else
-                    {
-                        @if (string.IsNullOrEmpty(MiniTag.Tag.Category.ToString()))
-                        {
-                            <span class="badge badge-primary">
-                                @MiniTag.Tag.TagName
-                            </span>
-                        }
-                        else
-                        {
-                            <span class="badge badge-primary">
-                                <small>@MiniTag.Tag.Category:</small> @MiniTag.Tag.TagName
-                            </span>
-                        }
-                    }
+                    <span class="badge badge-primary" style="font-size:large">
+                        <b>@MiniTag.Tag.TagName</b>
+                    </span>
                 }
-            </div>
-            <div id="AddedTags">
-            </div>
+                else
+                {
+                    <span class="badge badge-primary" style="font-size:large; margin:2px;">
+                        @MiniTag.Tag.Category: <b>@MiniTag.Tag.TagName</b>
+                    </span>
+                }
+            }
         </div>
     </div>
+    <div class="row">
+        <div class="col-md-6">
 
-    @if (SignInManager.IsSignedIn(User))
-    {
-
-        <div class="row">
-            <div class="col-md-12">
-
-                <hr />
-
-                <h2>Add Tags</h2>
-                Filter <input id="tagSearch" type="text" />
-
-                <hr />
-
-                <div id="UnusedTags">
-
-                    <div class="add-tag-div">
-                        <h3 class="add-tag-header">Quick Tag</h3>
-                        @foreach (var Tag in Model.RecommendedTags)
-                        {
-                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                        }
-                    </div>
-
-                    <hr />
-
-                    <div class="add-tag-div">
-                        <h3 class="add-tag-header">Genre</h3>
-                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Genre"))
-                        {
-                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                        }
-                    </div>
-
-                    <div class="add-tag-div">
-                        <h3 class="add-tag-header">Use</h3>
-                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Use"))
-                        {
-                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                        }
-                    </div>
-
-                    @{var PreviousCategory = "";}
-                    <div class="add-tag-div">
-
-                        @foreach (var Tag in Model.UnusedTags
-                       .Where(m => !string.IsNullOrEmpty(m.Category.ToString())
-                           && m.Category != TagCategory.Genre
-                           && m.Category != TagCategory.OtherDescription
-                           && m.Category != TagCategory.CreatureName
-                           && m.Category != TagCategory.Use))
-                        {
-                            @if (Tag.Category.ToString() != PreviousCategory)
-                            {
-                            @:</div>
-                            @:<div class="add-tag-div">
-                                if (string.IsNullOrEmpty(Tag.Category.ToString()))
-                                {
-                                    <hr />
-                                }
-                                else
-                                {
-                                    <h3 class="add-tag-header">@Tag.Category</h3>
-                                }
-
-                            }
-                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                            PreviousCategory = Tag.Category.ToString();
-                        }
-                    </div>
-                    <div class="add-tag-div">
-                        <h3 class="add-tag-header">Creature Name</h3>
-                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "CreatureName"))
-                        {
-                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                        }
-                    </div>
-                    <hr />
-                    <h3>Other Tags</h3>
-                    @foreach (var Tag in Model.UnusedTags.Where(m => string.IsNullOrEmpty(m.Category.ToString()) || m.Category.ToString() == "OtherDescription"))
-                    {
-                        <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                    }
-                </div>
-                <a href="#" id="AddNewTag" class="btn btn-success" style="margin-top:5px;">+ Add as new tag</a>
-            </div>
         </div>
-    }
+
+        <div class="col-md-6">
+            
+        </div>
+    </div>
 </div>

--- a/MiniIndex/Pages/Minis/Details.cshtml.cs
+++ b/MiniIndex/Pages/Minis/Details.cshtml.cs
@@ -25,14 +25,10 @@ namespace MiniIndex.Pages.Minis
         private readonly TelemetryClient _telemetry;
 
         public Mini Mini { get; set; }
-        public List<Tag> UnusedTags { get; set; }
-        public List<Tag> RecommendedTags { get; set; }
         public bool IsStarred { get; set; }
-        public string ShowHelp { get; set; }
 
-        public async Task<IActionResult> OnGetAsync(int? id, string showHelp="")
+        public async Task<IActionResult> OnGetAsync(int? id)
         {
-            ShowHelp = showHelp;
             IdentityUser CurrentUser = await _userManager.GetUserAsync(User);
 
             if (id == null)
@@ -64,22 +60,6 @@ namespace MiniIndex.Pages.Minis
             {
                 IsStarred = false;
             }
-
-            //TODO - 99% confident this is wrong.
-            UnusedTags = _context
-                .Tag
-                .AsEnumerable()
-                .Except(Mini.MiniTags.Where(mt=>mt.Status==Status.Pending).Select(mt => mt.Tag))
-                .OrderBy(m => m.Category.ToString())
-                .ThenBy(m => m.TagName)
-                .ToList();
-
-
-            string[] nameSplit = Mini.Name.ToUpperInvariant().Split(' ');
-
-            RecommendedTags = UnusedTags
-                .Where(t => nameSplit.Contains(t.TagName.ToUpperInvariant()))
-                .ToList();
 
             return Page();
         }

--- a/MiniIndex/Pages/Minis/Details.cshtml.cs
+++ b/MiniIndex/Pages/Minis/Details.cshtml.cs
@@ -65,10 +65,11 @@ namespace MiniIndex.Pages.Minis
                 IsStarred = false;
             }
 
+            //TODO - 99% confident this is wrong.
             UnusedTags = _context
                 .Tag
                 .AsEnumerable()
-                .Except(Mini.MiniTags.Select(mt => mt.Tag))
+                .Except(Mini.MiniTags.Where(mt=>mt.Status==Status.Pending).Select(mt => mt.Tag))
                 .OrderBy(m => m.Category.ToString())
                 .ThenBy(m => m.TagName)
                 .ToList();

--- a/MiniIndex/Pages/Minis/Edit.cshtml
+++ b/MiniIndex/Pages/Minis/Edit.cshtml
@@ -1,87 +1,214 @@
 ﻿@page
+@using MiniIndex.Models;
 @model MiniIndex.Pages.Minis.EditModel
-
 @inject SignInManager<IdentityUser> SignInManager
-
 @{
     ViewData["Title"] = "Edit";
 }
 
-@section Scripts {
-    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+@section Scripts
+{
+    <environment include="Development">
+        <script type="module" src="~/dist/stars.entry.js" defer></script>
+    </environment>
+
+    <environment exclude="Development">
+        <script type="module" src="https://miniindex.azureedge.net/stars.entry.js" defer></script>
+    </environment>
 }
 
-@if (User.IsInRole("Moderator"))
-{
-    <h2>Edit</h2>
-    <hr />
-    <div class="row">
-        <div class="col-md-6" align="center">
-            <a href="@Model.Mini.Link" class="btn btn-lg btn-primary">View On Thingiverse</a>
-            <hr />
-            <img src="@Model.Mini.Thumbnail" class="img-fluid rounded" />
+<div>
+    @if (User.IsInRole("Moderator"))
+    {
+        <div class="card shadow">
+            <div class="card-body">
+                <h2 class="card-title">Moderate</h2>
+                @if (User.IsInRole("Administrator"))
+                {
+                    <small>Submitted by @Model.Mini.User.Email</small>
+                }
+
+                <p><b>Current Status - </b>@Model.Mini.Status</p>
+                <p><b>Cost - </b>@Model.Mini.Cost</p>
+                <p><b>Thumbnail - </b>@Model.Mini.Thumbnail</p>
+                <hr />
+
+                <a asp-page="./UpdateStatus" asp-route-MiniID="@Model.Mini.ID" asp-route-NewStatus="Approved" class="btn btn-success">
+                    Approve
+                </a>
+                <a asp-page="./UpdateStatus" asp-route-MiniID="@Model.Mini.ID" asp-route-NewStatus="Pending" class="btn btn-warning">
+                    Visible
+                </a>
+                <a asp-page="./UpdateStatus" asp-route-MiniID="@Model.Mini.ID" asp-route-NewStatus="Rejected" class="btn btn-danger">
+                    Reject
+                </a>
+                <a asp-page="./UpdateStatus" asp-route-MiniID="@Model.Mini.ID" asp-route-NewStatus="Deleted" class="btn btn-danger">
+                    Delete
+                </a>
+                <hr />
+                <a asp-page="./FixThumbnail" asp-route-id="@Model.Mini.ID" class="btn btn-primary">
+                    Fix Thumbnail
+                </a>
+            </div>
         </div>
+    }
+</div>
+
+<div class="container">
+    <p id="miniid" style="display:none;">@Model.Mini.ID</p>
+    <div>
+        <a asp-page="./Details" asp-route-id="@Model.Mini.ID">Back to Mini</a>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h2 class="card-title">Tag Guidance</h2>
+            <p>
+                <b>Thanks for contributing to The Mini Index!</b><br />
+                We have some guidelines written about how to make your
+                tags great, please read through them <a href="https://github.com/aluhrs13/TheMiniIndex/wiki/How-to-tag-Minis">here.</a> At a minimum, please make sure you include
+                the genre, use, and any notable descriptions like the creature's name and type or race and gender.
+                Your Mini and tags will show up once a moderator gets a chance to look and approve it.
+            </p>
+
+            <p>If you're submitting a bunch of Minis from a single creator, we'll approve at most a few a day to not flood the front page with a single creator.</p>
+
+            <a href="/Minis/Help" class="btn btn-primary">Tag another Mini</a>
+            <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAANAAYEBbR1URVo3SDNGWTlENU5FNkw3VjRaNVJPVkVDRy4u" target="_blank" class="btn btn-secondary">
+                Something's wrong
+            </a>
+        </div>
+    </div>
+    <br />
+
+    <h2>@Html.DisplayFor(model => model.Mini.Name) by <a href="/Creators/Details?id=@Model.Mini.Creator.ID">@Html.DisplayFor(model => model.Mini.Creator.Name)</a></h2>
+    <hr />
+
+    <div class="row">
+        <div class="col-md-4" align="center">
+            <div class="row">
+                <div class="col-md-12">
+                    @if (Model.Mini.Sources.Any())
+                    {
+                        @foreach (var miniSource in Model.Mini.Sources)
+                        {
+                            <a href="@miniSource.Link" class="btn btn-block btn-primary @miniSource.Site.SiteName" style="margin-top:10px;">View On @miniSource.Site.SiteName</a>
+                        }
+                    }
+                    else if (!String.IsNullOrEmpty(Model.Mini.Link))
+                    {
+                        <a href="@Html.DisplayFor(modelItem => Model.Mini.Link)" class="btn btn-block btn-primary" style="margin-top:10px;">View at source</a>
+                    }
+                </div>
+            </div>
+
+            <hr />
+
+            @if (Model.Mini.Thumbnail.Contains("miniindex.blob.core.windows.net/"))
+            {
+                <img class="img-fluid rounded" src="@Model.Mini.Thumbnail.Replace("miniindex.blob.core.windows.net", "miniindexblobcdn.azureedge.net")" />
+            }
+            else
+            {
+                <img class="img-fluid rounded" src="@Model.Mini.Thumbnail" />
+            }
+        </div>
+
         <div class="col-md-6">
-            <form method="post">
+            <h3>Tags</h3>
+            <hr/>
+            <!-- <img src="~/images/icons/apple-touch-icon-152x152.png" class="loading-spinner" style="display:none;"/> -->
+            <div id="UsedTags">
+                
+            </div>
+        </div>
+    </div>
+ 
 
-                <div class="form-group">
-                    <input asp-for="Mini.Link" class="form-control" />
-                </div>
-
-                <div class="form-group">
-                    <input asp-for="Mini.Thumbnail" class="form-control" />
-                </div>
-
-                <div class="form-group">
-                    <input asp-for="Mini.ID" class="form-control" />
-                </div>
-
-                <div class="form-group">
-                    <input asp-for="Mini.Cost" class="form-control" />
-                </div>
-
-                <div class="row">
-                    <div class="col-md-3">
-                        <label asp-for="Mini.Status" class="control-label"></label>
-                    </div>
-                    <div class="col-md-9">
-                        <select asp-for="Mini.Status" asp-items="Html.GetEnumSelectList<MiniIndex.Models.Status>().OrderBy(m => m.Text)" class="form-control">
-                            <option selected="selected" value=""></option>
-                        </select>
-                        <span asp-validation-for="Mini.Status" class="text-danger"></span>
-                    </div>
-                </div>
+        <div class="row">
+            <div class="col-md-12">
 
                 <hr />
 
-                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <h2>Add Tags</h2>
+                Filter <input id="tagSearch" type="text" />
 
-                <div class="form-group">
-                    <div class="row">
-                        <div class="col-md-3">
-                            <label asp-for="Mini.Name" class="control-label"></label>
+                <hr />
+
+                <div id="UnusedTags">
+
+                    @if (Model.RecommendedTags.Count > 0)
+                    {
+                        <div class="add-tag-div">
+                            <h3 class="add-tag-header">Quick Tag</h3>
+                            @foreach (var Tag in Model.RecommendedTags)
+                            {
+                                <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                            }
                         </div>
-                        <div class="col-md-9">
-                            <input asp-for="Mini.Name" class="form-control" readonly="readonly" />
-                            <span asp-validation-for="Mini.Name" class="text-danger"></span>
-                        </div>
+
+                        <hr />
+                    }
+
+                    <div class="add-tag-div">
+                        <h3 class="add-tag-header">Genre</h3>
+                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Genre"))
+                        {
+                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                        }
                     </div>
 
-                    <div class="row">
-                        <div class="col-md-3">
-                            <label asp-for="Mini.Creator" class="control-label"></label>
-                        </div>
-                        <div class="col-md-9">
-                            <select asp-for="Mini.Creator.ID" class="form-control" asp-items="@Model.CreatorSL">
-                                <option value="">-- Select Creator --</option>
-                            </select>
-                            <span asp-validation-for="Mini.Creator" class="text-danger" />
-                        </div>
+                    <div class="add-tag-div">
+                        <h3 class="add-tag-header">Use</h3>
+                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Use"))
+                        {
+                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                        }
                     </div>
 
-                    <input type="submit" value="Submit!" class="btn btn-success" />
+                    @{var PreviousCategory = "";}
+                    <div class="add-tag-div">
+
+                        @foreach (var Tag in Model.UnusedTags
+                     .Where(m => !string.IsNullOrEmpty(m.Category.ToString())
+                         && m.Category != TagCategory.Genre
+                         && m.Category != TagCategory.OtherDescription
+                         && m.Category != TagCategory.CreatureName
+                         && m.Category != TagCategory.Use))
+                        {
+                            @if (Tag.Category.ToString() != PreviousCategory)
+                            {
+                            @:</div>
+                            @:<div class="add-tag-div">
+                                if (string.IsNullOrEmpty(Tag.Category.ToString()))
+                                {
+                                    <hr />
+                                }
+                                else
+                                {
+                                    <h3 class="add-tag-header">@Tag.Category</h3>
+                                }
+
+                            }
+                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                            PreviousCategory = Tag.Category.ToString();
+                        }
+                    </div>
+                    <div class="add-tag-div">
+                        <h3 class="add-tag-header">Creature Name</h3>
+                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "CreatureName"))
+                        {
+                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                        }
+                    </div>
+                    <hr />
+                    <h3>Other Tags</h3>
+                    @foreach (var Tag in Model.UnusedTags.Where(m => string.IsNullOrEmpty(m.Category.ToString()) || m.Category.ToString() == "OtherDescription"))
+                    {
+                        <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                    }
                 </div>
-            </form>
+                <a href="#" id="AddNewTag" class="btn btn-success" style="margin-top:5px;">+ Add as new tag</a>
+            </div>
         </div>
-    </div>
-}
+</div>

--- a/MiniIndex/Pages/Minis/Edit.cshtml
+++ b/MiniIndex/Pages/Minis/Edit.cshtml
@@ -2,6 +2,8 @@
 @using MiniIndex.Models;
 @model MiniIndex.Pages.Minis.EditModel
 @inject SignInManager<IdentityUser> SignInManager
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
 @{
     ViewData["Title"] = "Edit";
 }
@@ -68,10 +70,11 @@
                 We have some guidelines written about how to make your
                 tags great, please read through them <a href="https://github.com/aluhrs13/TheMiniIndex/wiki/How-to-tag-Minis">here.</a> At a minimum, please make sure you include
                 the genre, use, and any notable descriptions like the creature's name and type or race and gender.
-                Your Mini and tags will show up once a moderator gets a chance to look and approve it.
+                Your Mini and tags will show up once a moderator gets a chance to look and approve it. If you're submitting a bunch of Minis from a single creator, we'll approve at most a few a day to not flood the front page with a single creator.
             </p>
 
-            <p>If you're submitting a bunch of Minis from a single creator, we'll approve at most a few a day to not flood the front page with a single creator.</p>
+            <p><b>We're also experimenting with automatic tag additions soon, when adding a tag you may notice more tags than the one you clicked getting added. Feel free to remove those, and if they
+                appear extremely wrong, hit the "Something's wrong" button below and let us know what you don't like!</b></p>
 
             <a href="/Minis/Help" class="btn btn-primary">Tag another Mini</a>
             <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=DQSIkWdsW0yxEjajBLZtrQAAAAAAAAAAAANAAYEBbR1URVo3SDNGWTlENU5FNkw3VjRaNVJPVkVDRy4u" target="_blank" class="btn btn-secondary">
@@ -106,7 +109,7 @@
 
             @if (Model.Mini.Thumbnail.Contains("miniindex.blob.core.windows.net/"))
             {
-                <img class="img-fluid rounded" src="@Model.Mini.Thumbnail.Replace("miniindex.blob.core.windows.net", "miniindexblobcdn.azureedge.net")" />
+                <img class="img-fluid rounded" src="@Model.Mini.Thumbnail.Replace("miniindex.blob.core.windows.net", Configuration["CDNURL"]+".azureedge.net")" />
             }
             else
             {
@@ -116,99 +119,99 @@
 
         <div class="col-md-6">
             <h3>Tags</h3>
-            <hr/>
+            <hr />
             <!-- <img src="~/images/icons/apple-touch-icon-152x152.png" class="loading-spinner" style="display:none;"/> -->
             <div id="UsedTags">
-                
+
             </div>
         </div>
     </div>
- 
 
-        <div class="row">
-            <div class="col-md-12">
 
-                <hr />
+    <div class="row">
+        <div class="col-md-12">
 
-                <h2>Add Tags</h2>
-                Filter <input id="tagSearch" type="text" />
+            <hr />
 
-                <hr />
+            <h2>Add Tags</h2>
+            Filter <input id="tagSearch" type="text" />
 
-                <div id="UnusedTags">
+            <hr />
 
-                    @if (Model.RecommendedTags.Count > 0)
-                    {
-                        <div class="add-tag-div">
-                            <h3 class="add-tag-header">Quick Tag</h3>
-                            @foreach (var Tag in Model.RecommendedTags)
-                            {
-                                <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                            }
-                        </div>
+            <div id="UnusedTags">
 
-                        <hr />
-                    }
-
+                @if (Model.RecommendedTags.Count > 0)
+                {
                     <div class="add-tag-div">
-                        <h3 class="add-tag-header">Genre</h3>
-                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Genre"))
+                        <h3 class="add-tag-header">Quick Tag</h3>
+                        @foreach (var Tag in Model.RecommendedTags)
                         {
                             <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
                         }
                     </div>
 
-                    <div class="add-tag-div">
-                        <h3 class="add-tag-header">Use</h3>
-                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Use"))
-                        {
-                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                        }
-                    </div>
-
-                    @{var PreviousCategory = "";}
-                    <div class="add-tag-div">
-
-                        @foreach (var Tag in Model.UnusedTags
-                     .Where(m => !string.IsNullOrEmpty(m.Category.ToString())
-                         && m.Category != TagCategory.Genre
-                         && m.Category != TagCategory.OtherDescription
-                         && m.Category != TagCategory.CreatureName
-                         && m.Category != TagCategory.Use))
-                        {
-                            @if (Tag.Category.ToString() != PreviousCategory)
-                            {
-                            @:</div>
-                            @:<div class="add-tag-div">
-                                if (string.IsNullOrEmpty(Tag.Category.ToString()))
-                                {
-                                    <hr />
-                                }
-                                else
-                                {
-                                    <h3 class="add-tag-header">@Tag.Category</h3>
-                                }
-
-                            }
-                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                            PreviousCategory = Tag.Category.ToString();
-                        }
-                    </div>
-                    <div class="add-tag-div">
-                        <h3 class="add-tag-header">Creature Name</h3>
-                        @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "CreatureName"))
-                        {
-                            <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
-                        }
-                    </div>
                     <hr />
-                    <h3>Other Tags</h3>
-                    @foreach (var Tag in Model.UnusedTags.Where(m => string.IsNullOrEmpty(m.Category.ToString()) || m.Category.ToString() == "OtherDescription"))
+                }
+
+                <div class="add-tag-div">
+                    <h3 class="add-tag-header">Genre</h3>
+                    @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Genre"))
                     {
                         <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
                     }
                 </div>
-                <a href="#" id="AddNewTag" class="btn btn-success" style="margin-top:5px;">+ Add as new tag</a>
+
+                <div class="add-tag-div">
+                    <h3 class="add-tag-header">Use</h3>
+                    @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "Use"))
+                    {
+                        <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                    }
+                </div>
+
+                @{var PreviousCategory = "";}
+                <div class="add-tag-div">
+
+                    @foreach (var Tag in Model.UnusedTags
+                .Where(m => !string.IsNullOrEmpty(m.Category.ToString())
+                    && m.Category != TagCategory.Genre
+                    && m.Category != TagCategory.OtherDescription
+                    && m.Category != TagCategory.CreatureName
+                    && m.Category != TagCategory.Use))
+                    {
+                        @if (Tag.Category.ToString() != PreviousCategory)
+                        {
+                        @:</div>
+                        @:<div class="add-tag-div">
+                            if (string.IsNullOrEmpty(Tag.Category.ToString()))
+                            {
+                                <hr />
+                            }
+                            else
+                            {
+                                <h3 class="add-tag-header">@Tag.Category</h3>
+                            }
+
+                        }
+                        <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                        PreviousCategory = Tag.Category.ToString();
+                    }
+                </div>
+                <div class="add-tag-div">
+                    <h3 class="add-tag-header">Creature Name</h3>
+                    @foreach (var Tag in Model.UnusedTags.Where(m => m.Category.ToString() == "CreatureName"))
+                    {
+                        <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                    }
+                </div>
+                <hr />
+                <h3>Other Tags</h3>
+                @foreach (var Tag in Model.UnusedTags.Where(m => string.IsNullOrEmpty(m.Category.ToString()) || m.Category.ToString() == "OtherDescription"))
+                {
+                    <a href="#" id="@Tag.ID" class="btn btn-outline-success add-tag" style="margin-top:5px;">+ @Tag.TagName</a>
+                }
             </div>
+            <a href="#" id="AddNewTag" class="btn btn-success" style="margin-top:5px;">+ Add as new tag</a>
         </div>
+    </div>
 </div>

--- a/MiniIndex/Pages/Minis/Help.cshtml
+++ b/MiniIndex/Pages/Minis/Help.cshtml
@@ -29,7 +29,7 @@
 
                 <div class="col-md-4">
                     <div class="card mb-4 shadow-sm">
-                        <a asp-page="./Details" asp-route-id="@item.ID">
+                        <a asp-page="./Edit" asp-route-id="@item.ID">
                             <img class="card-img-top" src="@item.Thumbnail" width="314" height="236" />
                         </a>
                     </div>

--- a/MiniIndex/Pages/Minis/Help.cshtml.cs
+++ b/MiniIndex/Pages/Minis/Help.cshtml.cs
@@ -32,7 +32,7 @@ namespace MiniIndex.Pages.Minis
                         .Where(m => m.Status == Status.Pending)
                         .ToListAsync();
 
-            return RedirectToPage("./Details", new { id = Mini[rnd.Next(Mini.Count)].ID, showHelp = "tag" });
+            return RedirectToPage("./Edit", new { id = Mini[rnd.Next(Mini.Count)].ID, showHelp = "tag" });
         }
     }
 }

--- a/MiniIndex/Pages/Minis/UpdateStatus.cshtml.cs
+++ b/MiniIndex/Pages/Minis/UpdateStatus.cshtml.cs
@@ -38,7 +38,9 @@ namespace MiniIndex.Pages.Minis
                     return NotFound();
                 }
 
-                Mini = await _context.Mini.FirstOrDefaultAsync(m => m.ID == MiniID);
+                Mini = await _context.Mini
+                                .Include(m=>m.MiniTags)
+                                .FirstOrDefaultAsync(m => m.ID == MiniID);
 
                 if (Mini == null)
                 {
@@ -54,6 +56,7 @@ namespace MiniIndex.Pages.Minis
                         mt.Status = Status.Approved;
                         mt.ApprovedTime = DateTime.Now;
                         mt.LastModifiedTime = DateTime.Now;
+                        _context.Attach(mt).State = EntityState.Modified;
                     }
                     _context.Attach(Mini).State = EntityState.Modified;
                 }

--- a/MiniIndex/Pages/Minis/UpdateStatus.cshtml.cs
+++ b/MiniIndex/Pages/Minis/UpdateStatus.cshtml.cs
@@ -53,10 +53,13 @@ namespace MiniIndex.Pages.Minis
                     Mini.ApprovedTime = DateTime.Now;
                     foreach(MiniTag mt in Mini.MiniTags)
                     {
-                        mt.Status = Status.Approved;
-                        mt.ApprovedTime = DateTime.Now;
-                        mt.LastModifiedTime = DateTime.Now;
-                        _context.Attach(mt).State = EntityState.Modified;
+                        if(mt.Status == Status.Pending)
+                        {
+                            mt.Status = Status.Approved;
+                            mt.ApprovedTime = DateTime.Now;
+                            mt.LastModifiedTime = DateTime.Now;
+                            _context.Attach(mt).State = EntityState.Modified;
+                        }
                     }
                     _context.Attach(Mini).State = EntityState.Modified;
                 }

--- a/MiniIndex/Pages/Minis/UpdateStatus.cshtml.cs
+++ b/MiniIndex/Pages/Minis/UpdateStatus.cshtml.cs
@@ -49,6 +49,12 @@ namespace MiniIndex.Pages.Minis
                 {
                     Mini.Status = Status.Approved;
                     Mini.ApprovedTime = DateTime.Now;
+                    foreach(MiniTag mt in Mini.MiniTags)
+                    {
+                        mt.Status = Status.Approved;
+                        mt.ApprovedTime = DateTime.Now;
+                        mt.LastModifiedTime = DateTime.Now;
+                    }
                     _context.Attach(Mini).State = EntityState.Modified;
                 }
 

--- a/MiniIndex/Pages/Shared/_Layout.cshtml
+++ b/MiniIndex/Pages/Shared/_Layout.cshtml
@@ -15,11 +15,13 @@
     <link rel="apple-touch-icon-precomposed" sizes="120x120" href="~/images/icons/apple-touch-icon-120x120.png" />
     <link rel="apple-touch-icon-precomposed" sizes="76x76" href="~/images/icons/apple-touch-icon-76x76.png" />
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="~/images/icons/apple-touch-icon-152x152.png" />
+
     <link rel="icon" type="image/png" href="~/images/icons/favicon-196x196.png" sizes="196x196" />
     <link rel="icon" type="image/png" href="~/images/icons/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/png" href="~/images/icons/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="~/images/icons/favicon-16x16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="~/images/icons/favicon-128.png" sizes="128x128" />
+
     <meta name="application-name" content="The Mini Index" />
     <meta name="msapplication-TileColor" content="#FFFFFF" />
     <meta name="msapplication-TileImage" content="~/images/icons/mstile-144x144.png" />
@@ -38,10 +40,6 @@
     <meta name="twitter:image:src" content="https://theminiindex.com/images/icons/favicon-196x196.png">
     <meta name="twitter:description" content="The Mini Index is a crowd-sourced index of various minis, terrain tiles, and scatter terrain across different websites for use with tabletop games like Dungeons and Dragons." />
     <meta name="twitter:title" content="@ViewData["Title"] - The Mini Index" />
-
-    <script type="module" src="https://miniindex.azureedge.net/site.entry.js" defer></script>
-    <script type="module" src="https://miniindex.azureedge.net/bootstrapjs.entry.js" defer></script>
-    <link rel="stylesheet" href="https://miniindex.azureedge.net/site.css">
 
     <environment include="Development">
         <script type="module" src="~/dist/validation.entry.js" defer></script>

--- a/MiniIndex/Pages/Shared/_Layout.cshtml
+++ b/MiniIndex/Pages/Shared/_Layout.cshtml
@@ -43,6 +43,19 @@
     <script type="module" src="https://miniindex.azureedge.net/bootstrapjs.entry.js" defer></script>
     <link rel="stylesheet" href="https://miniindex.azureedge.net/site.css">
 
+    <environment include="Development">
+        <script type="module" src="~/dist/validation.entry.js" defer></script>
+        <script type="module" src="~/dist/site.entry.js" defer></script>
+        <script type="module" src="~/dist/bootstrapjs.entry.js" defer></script>
+        <link rel="stylesheet" href="~/dist/site.css">
+    </environment>
+
+    <environment exclude="Development">
+        <script type="module" src="https://miniindex.azureedge.net/site.entry.js" defer></script>
+        <script type="module" src="https://miniindex.azureedge.net/bootstrapjs.entry.js" defer></script>
+        <link rel="stylesheet" href="https://miniindex.azureedge.net/site.css">
+    </environment>
+
     <script type="text/javascript">
         var appInsights = window.appInsights || function (a) {
             function b(a) { c[a] = function () { var b = arguments; c.queue.push(function () { c[a].apply(c, b) }) } } var c = { config: a }, d = document, e = window; setTimeout(function () { var b = d.createElement("script"); b.src = a.url || "https://az416426.vo.msecnd.net/scripts/a/ai.0.js", d.getElementsByTagName("script")[0].parentNode.appendChild(b) }); try { c.cookie = d.cookie } catch (a) { } c.queue = []; for (var f = ["Event", "Exception", "Metric", "PageView", "Trace", "Dependency"]; f.length;)b("track" + f.pop()); if (b("setAuthenticatedUserContext"), b("clearAuthenticatedUserContext"), b("startTrackEvent"), b("stopTrackEvent"), b("startTrackPage"), b("stopTrackPage"), b("flush"), !a.disableExceptionTracking) { f = "onerror", b("_" + f); var g = e[f]; e[f] = function (a, b, d, e, h) { var i = g && g(a, b, d, e, h); return !0 !== i && c["_" + f](a, b, d, e, h), i } } return c

--- a/MiniIndex/Pages/Shared/_ValidationScriptsPartial.cshtml
+++ b/MiniIndex/Pages/Shared/_ValidationScriptsPartial.cshtml
@@ -1,1 +1,7 @@
-﻿<script type="module" src="https://miniindex.azureedge.net/validation.entry.js" defer></script>
+﻿<environment include="Development">
+    <script type="module" src="~/dist/validation.entry.js" defer></script>
+</environment>
+
+<environment exclude="Development">
+    <script type="module" src="https://miniindex.azureedge.net/validation.entry.js" defer></script>
+</environment>

--- a/MiniIndex/Pages/TagPairs/Create.cshtml
+++ b/MiniIndex/Pages/TagPairs/Create.cshtml
@@ -1,0 +1,6 @@
+﻿@page
+@model MiniIndex.Pages.TagPairs.CreateModel
+
+@{ 
+
+}

--- a/MiniIndex/Pages/TagPairs/Create.cshtml.cs
+++ b/MiniIndex/Pages/TagPairs/Create.cshtml.cs
@@ -33,9 +33,18 @@ namespace MiniIndex.Pages.TagPairs
             {
                 Tag Tag1 = _context.Tag.FirstOrDefault(t => t.ID == tag1);
                 Tag Tag2 = _context.Tag.FirstOrDefault(t => t.ID == tag2);
-                PairType pairType =  (PairType)type;
+                PairType pairType = (PairType)type;
 
-                if(Tag1 == null | Tag2 == null || pairType == null)
+                //TODO - This is a hack. 99 means "child" from the tag manager, so we're swapping them.
+                //It's a dumb hack, but I'm tired.
+                if (type == 99)
+                {
+                    Tag1 = _context.Tag.FirstOrDefault(t => t.ID == tag2);
+                    Tag2 = _context.Tag.FirstOrDefault(t => t.ID == tag1);
+                    pairType = PairType.Parent;
+                }
+
+                if(Tag1 == null | Tag2 == null)
                 {
                     return NotFound();
                 }

--- a/MiniIndex/Pages/TagPairs/Create.cshtml.cs
+++ b/MiniIndex/Pages/TagPairs/Create.cshtml.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using MiniIndex.Models;
+using MiniIndex.Persistence;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MiniIndex.Pages.TagPairs
+{
+    [Authorize]
+    public class CreateModel : PageModel
+    {
+        public CreateModel(
+                UserManager<IdentityUser> userManager,
+                MiniIndexContext context)
+        {
+            _context = context;
+            _userManager = userManager;
+        }
+
+        private readonly MiniIndexContext _context;
+        private readonly UserManager<IdentityUser> _userManager;
+
+        public async Task<IActionResult> OnGet(int tag1, int tag2, int type)
+        {
+
+            if (User.IsInRole("Moderator"))
+            {
+                Tag Tag1 = _context.Tag.FirstOrDefault(t => t.ID == tag1);
+                Tag Tag2 = _context.Tag.FirstOrDefault(t => t.ID == tag2);
+                PairType pairType =  (PairType)type;
+
+                if(Tag1 == null | Tag2 == null || pairType == null)
+                {
+                    return NotFound();
+                }
+
+                TagPair newPair = new TagPair(){
+                    Tag1 = Tag1,
+                    Tag2 = Tag2,
+                    Type = pairType
+                };
+
+                if(_context.TagPair.Any(tp=> (tp.Tag1==Tag1 && tp.Tag2 == Tag2)))
+                {
+                    return NotFound();
+                }
+
+                _context.TagPair.Add(newPair);
+
+                await _context.SaveChangesAsync();
+                return Page();
+            }
+
+            return NotFound();
+        }
+    }
+}

--- a/MiniIndex/Pages/TagPairs/Delete.cshtml
+++ b/MiniIndex/Pages/TagPairs/Delete.cshtml
@@ -1,0 +1,6 @@
+﻿@page
+@model MiniIndex.Pages.TagPairs.DeleteModel
+
+@{
+}
+

--- a/MiniIndex/Pages/TagPairs/Delete.cshtml.cs
+++ b/MiniIndex/Pages/TagPairs/Delete.cshtml.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using MiniIndex.Models;
+using MiniIndex.Persistence;
+
+namespace MiniIndex.Pages.TagPairs
+{
+    [Authorize]
+    public class DeleteModel : PageModel
+    {
+        private readonly MiniIndexContext _context;
+
+        public DeleteModel(MiniIndexContext context)
+        {
+            _context = context;
+        }
+
+        public TagPair TagPair { get; private set; }
+
+        public async Task<IActionResult> OnGetAsync(int id)
+        {
+            if (User.IsInRole("Moderator"))
+            {
+                TagPair = await _context.TagPair.FindAsync(id);
+
+                _context.TagPair.Remove(TagPair);
+
+                await _context.SaveChangesAsync();
+                return Page();
+            }
+            return NotFound();
+        }
+    }
+}

--- a/MiniIndex/Pages/Tags/Manage.cshtml
+++ b/MiniIndex/Pages/Tags/Manage.cshtml
@@ -27,7 +27,7 @@
                 <a asp-page="/Admin/CategoryManager">Back to all tags</a>
             </div>
 
-            <h1>@Model.Tag.TagName</h1>
+            <h1>@Model.Tag.ID - @Model.Tag.TagName</h1>
 
             <select id="@Model.Tag.ID" asp-for="@Model.Tag.Category" asp-items="Html.GetEnumSelectList<MiniIndex.Models.TagCategory>().OrderBy(m => m.Text)" class="change-category">
                 <option selected="selected" value=""></option>

--- a/MiniIndex/Pages/Tags/Manage.cshtml
+++ b/MiniIndex/Pages/Tags/Manage.cshtml
@@ -64,6 +64,7 @@
                     <td>
                         <select id="new-pair-type" asp-items="Html.GetEnumSelectList<MiniIndex.Models.PairType>().OrderBy(m => m.Text)">
                             <option selected="selected" value=""></option>
+                            <option value="99">Child</option>
                         </select>
                     </td>
                     <td>

--- a/MiniIndex/Pages/Tags/Manage.cshtml
+++ b/MiniIndex/Pages/Tags/Manage.cshtml
@@ -1,0 +1,87 @@
+﻿@page
+@model MiniIndex.Pages.Tags.ManageModel
+@{
+    ViewData["Title"] = "Edit Tag";
+}
+
+@section Scripts
+{
+    <environment include="Development">
+        <script type="module" src="~/dist/stars.entry.js" defer></script>
+    </environment>
+
+    <environment exclude="Development">
+        <script type="module" src="https://miniindex.azureedge.net/stars.entry.js" defer></script>
+    </environment>
+}
+
+@if (User.IsInRole("Moderator"))
+{
+    <div class="row">
+        <div class="col-md-2">
+
+        </div>
+
+        <div class="col-md-8">
+            <div>
+                <a asp-page="/Admin/CategoryManager">Back to all tags</a>
+            </div>
+
+            <h1>@Model.Tag.TagName</h1>
+
+            <select id="@Model.Tag.ID" asp-for="@Model.Tag.Category" asp-items="Html.GetEnumSelectList<MiniIndex.Models.TagCategory>().OrderBy(m => m.Text)" class="change-category">
+                <option selected="selected" value=""></option>
+            </select>
+
+            <a href="/Minis/?Tags=@Model.Tag.TagName" class="btn btn-primary" target="_blank">View @Model.MiniCount Tagged</a>
+            <a href="/Tags/Delete?id=@Model.Tag.ID" class="btn btn-danger">Delete Tag</a>
+
+            <hr />
+
+            <h2>Tag Pairs</h2>
+            <table class="table">
+                @foreach (var item in Model.TagPairs)
+                {
+                    <tr id="@item.ID">
+                        <td>
+                            <a href="/Tags/Manage?id=@item.Tag1.ID">@Html.DisplayFor(modelItem => item.Tag1.TagName)</a>
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.Type)
+                        </td>
+                        <td>
+                            <a href="/Tags/Manage?id=@item.Tag2.ID">@Html.DisplayFor(modelItem => item.Tag2.TagName)</a>
+                        </td>
+                        <td>
+                            <a href="#" id="@item.ID" class="remove-pair btn btn-danger btn-block">
+                                <span class="oi oi-trash"></span>
+                            </a>
+                        </td>
+                    </tr>
+                }
+                <tr>
+                    <td>@Model.Tag.TagName</td>
+                    <td>
+                        <select id="new-pair-type" asp-items="Html.GetEnumSelectList<MiniIndex.Models.PairType>().OrderBy(m => m.Text)">
+                            <option selected="selected" value=""></option>
+                        </select>
+                    </td>
+                    <td>
+                        <select id="new-pair-tag" asp-items="@Model.TagOptions">
+                            <option selected="selected" value=""></option>
+                        </select>
+                    </td>
+                    <td>
+                        <a href="#" id="@Model.Tag.ID" class="new-pair btn btn-block btn-secondary">
+                            <span class="oi oi-plus"></span>
+                        </a>
+                    </td>
+                </tr>
+            </table>
+
+        </div>
+        <div class="col-md-2">
+
+        </div>
+    </div>
+}

--- a/MiniIndex/Pages/Tags/Manage.cshtml.cs
+++ b/MiniIndex/Pages/Tags/Manage.cshtml.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using MiniIndex.Models;
+using MiniIndex.Persistence;
+
+namespace MiniIndex.Pages.Tags
+{
+    [Authorize]
+    public class ManageModel : PageModel
+    {
+        public ManageModel(
+                UserManager<IdentityUser> userManager,
+                SignInManager<IdentityUser> signInManager,
+                MiniIndexContext context)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _context = context;
+        }
+
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly SignInManager<IdentityUser> _signInManager;
+        private readonly MiniIndexContext _context;
+
+        [BindProperty]
+        public Tag Tag { get; set; }
+
+        public IList<TagPair> TagPairs { get; set; }
+        public int MiniCount { get; set; }
+        public SelectList TagOptions{ get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int? id, string category)
+        {
+            IdentityUser CurrentUser = await _userManager.GetUserAsync(User);
+            if (User.IsInRole("Moderator"))
+            {
+                if (id == null)
+                {
+                    return NotFound();
+                }
+
+                if (!ModelState.IsValid)
+                {
+                    return Page();
+                }
+
+                Tag = await _context.Tag.FirstOrDefaultAsync(m => m.ID == id);
+
+                MiniCount = _context.Mini.Where(m => m.MiniTags.Any(mt => mt.TagID == Tag.ID)).ToList().Count;
+
+                TagPairs = _context.TagPair
+                                    .Where(tp => (tp.Tag1 == Tag || tp.Tag2 == Tag))
+                                    .Include(tp => tp.Tag1)
+                                    .Include(tp => tp.Tag2)
+                                    .ToList();
+
+                IList<Tag> allTags = _context.Tag.OrderBy(t => t.TagName).ToList();
+
+                TagOptions = new SelectList(allTags, "ID", "TagName");
+
+                return Page();
+
+            }
+
+            return NotFound();
+        }
+    }
+}

--- a/MiniIndex/appsettings.json
+++ b/MiniIndex/appsettings.json
@@ -14,5 +14,8 @@
     "ImageContainer": ""
   },
   "KeyVaultName": "miniindex-0-kv",
-  "AutoCreateKey": ""
+  "AutoCreateKey": "",
+  "CDNURL": "miniindexblobcdn",
+  "CreateTagPairs": "false",
+  "CreateWarningMessage":  ""
 }

--- a/MiniIndex/wwwroot/css/site.css
+++ b/MiniIndex/wwwroot/css/site.css
@@ -44,7 +44,7 @@ a:not(.btn):not(.nav-link):not(.badge):not(.navbar-brand) {
 }
 
 .Pending {
-    background-color: #FFF5A6;
+    background-color: #FFF5A6 !important;
 }
 
 .Unindexed {

--- a/MiniIndex/wwwroot/js/stars.js
+++ b/MiniIndex/wwwroot/js/stars.js
@@ -88,10 +88,31 @@ $('#AddNewTag').click(function () {
 $('.change-category').change(function () {
     $.get({
         url: "/Tags/Edit/",
-        data: { id: this.parentElement.parentElement.id, category: $(this).children("option:selected").text() },
+        data: { id: this.id, category: $(this).children("option:selected").text() },
         complete: function () {
         },
     });
 
+    return false;
+});
+
+
+$('.remove-pair').click(function () {
+    $.get({
+        url: "/TagPairs/Delete/",
+        data: { id: this.id },
+        complete: function () {
+        },
+    });
+    return false;
+});
+
+$('.new-pair').click(function () {
+    $.get({
+        url: "/TagPairs/Create/",
+        data: { tag1: this.id, tag2: document.getElementById("new-pair-tag").value, type: document.getElementById("new-pair-type").value },
+        complete: function () {
+        },
+    });
     return false;
 });


### PR DESCRIPTION
Generally hits - #197, #196, #186, and starts #179.

- Fixes dev builds to not use CDN
- Adds timestamps to MiniTags
- Adds TagPair concept
- Uses the status field of MiniTags everywhere
- Adds a MiniTag approval page
- Adds TagPair management UI
- Splits Mini Details and Edit pages
- Moves some things to config - CDN URL, a "Create Mini" warning, and TagPair walking.