### PR TITLE
Fixing AtelierStoria parser case of mini with variants without URL query

### DIFF
--- a/MiniIndex.Core/Minis/Parsers/AtelierStoria/AtelierStoriaParser.cs
+++ b/MiniIndex.Core/Minis/Parsers/AtelierStoria/AtelierStoriaParser.cs
@@ -45,6 +45,13 @@ namespace MiniIndex.Core.Minis.Parsers.AtelierStoria
             // Some minis have variants, in which case they have a single query parameter named variant.
             var variantId = url.Query.Split("=").Last();
 
+            // If the variant is not specified in the URL query, the default variant will be used when avaiable.
+            // If the default variant doesn't exist, variantId will still be an empty string.
+            if (variantId == "")
+            {
+                variantId = GetValueFromMeta(htmlDoc, "product:defaultvariant", "");
+            }
+
             Mini mini = new Mini()
             {
                 Creator = creator,


### PR DESCRIPTION
Fixes #216 , added another meta field on the site for minis with multiple variations to determine which is the default one to pick by the parser in case the parameter is not set in the URL query when adding the link to the site.